### PR TITLE
fix: add exclusions for jackson core libs on the springdoc-openapi-ui dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,21 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${version.springdoc.openapi}</version>
+            <exclusions>
+                <!-- exclude conflicting jackson core libraries -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
Updating the `springdoc-openapi-ui` dependency from versions 1.3.0 to 1.3.1, has caused a startup failure resulting with a number of ClassNotFound exceptions, mentioning the jackson core libraries.

After running the `mvn dependency:tree -Dverbose -Dincludes=com.fasterxml.jackson.core` command, I noticed conflicts in the versions of this library being used (as transitive dependencies).

As a work around, i've added exclusions for the jackson (databind/annotations/core) libraries on the `springdoc-openapi-ui` dependency, which were pointed out as conflicts by the dependency tree.