### PR TITLE
fix: update response body on create appeals endpoint to return id

### DIFF
--- a/src/main/java/uk/gov/companieshouse/controller/AppealController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/AppealController.java
@@ -74,7 +74,7 @@ public class AppealController {
                 .buildAndExpand(id)
                 .toUri();
 
-            return ResponseEntity.created(location).build();
+            return ResponseEntity.created(location).body(id);
 
         } catch (Exception ex) {
             LOGGER.error("Unable to create appeal for company number {}, penalty reference {} and user id {}",

--- a/src/test/java/uk/gov/companieshouse/controller/AppealControllerTest_POST.java
+++ b/src/test/java/uk/gov/companieshouse/controller/AppealControllerTest_POST.java
@@ -79,6 +79,7 @@ public class AppealControllerTest_POST {
                 .headers(createHttpHeaders())
                 .content(appeal))
                 .andExpect(status().isCreated())
+                .andExpect(content().json(TEST_RESOURCE_ID))
                 .andExpect(header().string(HttpHeaders.LOCATION, "http://localhost/companies/12345678/appeals/"
                 + TEST_RESOURCE_ID));
         }


### PR DESCRIPTION
Return response body containing appeal id string so that this can be parsed easily by the front end application.

<img width="1265" alt="Screenshot 2020-04-27 at 15 07 37" src="https://user-images.githubusercontent.com/16392604/80381590-0dbbb280-8899-11ea-8095-0b014c7aa331.png">
