### PR TITLE
fix: use internal api group

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,5 +1,5 @@
 app_name: lfp-appeals-api
-group: api 
+group: internalapi
 weight: 900
 routes:
   1: ^/companies/(.*)/appeals/.*


### PR DESCRIPTION
Make the Appeals API private by using internal api group in the `routes.yaml`