### PR TITLE
Removed deletion of failed appeals + updated logs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/service/AppealService.java
+++ b/src/main/java/uk/gov/companieshouse/service/AppealService.java
@@ -47,6 +47,7 @@ public class AppealService {
 
         String appealId = createAppealInMongoDB(appeal, userId);
         appeal.setId(appealId);
+        createContactInChips(appeal, userId);
 
         if (chipsConfiguration.isChipsEnabled()) {
             createContactInChips(appeal, userId);
@@ -77,8 +78,7 @@ public class AppealService {
         try {
             chipsRestClient.createContactInChips(chipsContact, chipsConfiguration.getChipsRestServiceUrl());
         } catch (ChipsServiceException chipsServiceException) {
-            LOGGER.debug("Deleting appeal with id {} from mongodb", appeal.getId());
-            appealRepository.deleteById(appeal.getId());
+            LOGGER.debug("Appeal with id {} has failed to create contact", appeal.getId());
             throw chipsServiceException;
         }
     }

--- a/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
@@ -120,9 +120,8 @@ public class AppealServiceTest {
     }
 
     @Test
-    public void testCreateAppealChipsEnabled_throwsExceptionIfChipsReturnsError() {
+    public void testCreateAppeal_throwsExceptionIfChipsReturnsError() {
 
-        when(chipsConfiguration.isChipsEnabled()).thenReturn(true);
         when(chipsConfiguration.getChipsRestServiceUrl()).thenReturn(TEST_CHIPS_URL);
 
         doThrow(ChipsServiceException.class).when(chipsRestClient).createContactInChips(any(ChipsContact.class), anyString());

--- a/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
@@ -1,5 +1,20 @@
 package uk.gov.companieshouse.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,22 +41,6 @@ import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 import uk.gov.companieshouse.model.Reason;
 import uk.gov.companieshouse.repository.AppealRepository;
-
-import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AppealServiceTest {
@@ -134,7 +133,6 @@ public class AppealServiceTest {
         assertThrows(ChipsServiceException.class, () -> appealService.saveAppeal(createAppeal(), TestData.Appeal.CreatedBy.id));
 
         verify(appealRepository).insert(createAppealEntity(null));
-        verify(appealRepository).deleteById(TestData.Appeal.id);
     }
 
     @Test


### PR DESCRIPTION
Removed the deletion of failed Appeals as to allow them to be resent via the API. 

Logger has been updated to show the ID of the failed appeal. 

Unit tests updated to reflect changes

Resolves https://companieshouse.atlassian.net/browse/BI-8264