### PR TITLE
Add validation to only allow one Appeal Reason to be submitted

### DIFF
--- a/src/main/java/uk/gov/companieshouse/exception/AppealReasonException.java
+++ b/src/main/java/uk/gov/companieshouse/exception/AppealReasonException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.exception;
+
+public class AppealReasonException extends RuntimeException {
+    public AppealReasonException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/model/IllnessReason.java
+++ b/src/main/java/uk/gov/companieshouse/model/IllnessReason.java
@@ -3,16 +3,28 @@ package uk.gov.companieshouse.model;
 import java.util.Collections;
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Valid
 public class IllnessReason extends ReasonType {
 
+    @NotBlank(message = "illPerson must not be blank")
     private final String illPerson;
-    private final String otherPerson;
+
+    @NotBlank(message = "illnessStart must not be blank")
     private final String illnessStart;
+
+    @NotNull(message = "continuedIllness must not be null")
     private final boolean continuedIllness;
-    private final String illnessEnd;
+
+    @NotBlank(message = "illnessImpactFurtherInformation must not be blank")
     private final String illnessImpactFurtherInformation;
+
+    private final String otherPerson;
+    private final String illnessEnd;
+
+    @Valid
     private List<Attachment> attachments;
 
     public IllnessReason(){

--- a/src/main/java/uk/gov/companieshouse/model/Reason.java
+++ b/src/main/java/uk/gov/companieshouse/model/Reason.java
@@ -7,6 +7,7 @@ public class Reason {
 
     @Valid
     private OtherReason other;
+    @Valid
     private IllnessReason illnessReason;
 
     public Reason() {

--- a/src/main/java/uk/gov/companieshouse/model/validator/AppealReasonValidator.java
+++ b/src/main/java/uk/gov/companieshouse/model/validator/AppealReasonValidator.java
@@ -12,7 +12,7 @@ public class AppealReasonValidator {
     private static final Logger LOGGER = LoggerFactory.getLogger(AppealReasonValidator.class);
 
     public void validate(Reason reason) throws AppealReasonException {
-        if(reason.getOther() == null ^ reason.getIllnessReason() == null){
+        if(reason.getReasonType() != null){
             LOGGER.info("Correctly posted {} appeal reason", reason.getReasonType());
         }
         else {

--- a/src/main/java/uk/gov/companieshouse/model/validator/AppealReasonValidator.java
+++ b/src/main/java/uk/gov/companieshouse/model/validator/AppealReasonValidator.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.model.validator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.exception.AppealReasonException;
+import uk.gov.companieshouse.model.Reason;
+
+@Component
+public class AppealReasonValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealReasonValidator.class);
+
+    public void validate(Reason reason) throws AppealReasonException {
+        if(reason.getOther() == null ^ reason.getIllnessReason() == null){
+            LOGGER.info("Correctly posted {} appeal reason", reason.getReasonType());
+        }
+        else {
+            throw new AppealReasonException("Invalid appeal reason");
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/controller/AppealControllerTest_POST.java
+++ b/src/test/java/uk/gov/companieshouse/controller/AppealControllerTest_POST.java
@@ -147,6 +147,18 @@ public class AppealControllerTest_POST {
     }
 
     @Test
+    void whenInvalidAppealReason_return400() throws Exception {
+        final String invalidAppeal = asJsonString
+            ("src/test/resources/data/invalidAppealReason.json", appeal -> { return appeal; });
+
+        mockMvc.perform(post(APPEALS_URI, TEST_COMPANY_ID)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .headers(createHttpHeaders())
+            .content(invalidAppeal))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void whenExceptionFromService_return500() throws Exception {
 
         when(appealService.saveAppeal(any(Appeal.class), any(String.class)))

--- a/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.model.validator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.companieshouse.TestData;
+import uk.gov.companieshouse.exception.AppealReasonException;
+import uk.gov.companieshouse.model.Attachment;
+import uk.gov.companieshouse.model.IllnessReason;
+import uk.gov.companieshouse.model.OtherReason;
+import uk.gov.companieshouse.model.Reason;
+
+@ExtendWith(SpringExtension.class)
+class AppealReasonValidatorTest {
+
+    @Mock
+    private Reason mockReason = new Reason();
+
+    @InjectMocks
+    private AppealReasonValidator appealReasonValidator;
+
+    @Test
+    void shouldThrowAnExceptionWhenItsNotIllnessOrOtherReason() {
+        assertThrows(AppealReasonException.class, () -> appealReasonValidator.validate(mockReason));
+    }
+
+    @Test
+    void shouldThrowAnExceptionWhenHasBothIllnessAndOtherReason() {
+        mockReason = new Reason(createOtherReason(), createIllnessReason());
+        assertThrows(AppealReasonException.class, () -> appealReasonValidator.validate(mockReason));
+    }
+
+    @Test
+    void shouldNotThrowErrorWhenItsIllnessReason(){
+        mockReason = new Reason(null, createIllnessReason());
+        assertDoesNotThrow(() -> appealReasonValidator.validate(mockReason));
+    }
+
+    @Test
+    void shouldNotThrowErrorWhenItsOtherReason(){
+        mockReason = new Reason(createOtherReason(), null);
+        assertDoesNotThrow(() -> appealReasonValidator.validate(mockReason));
+    }
+
+    private IllnessReason createIllnessReason(){
+        return new IllnessReason(
+            TestData.Appeal.Reason.IllnessReason.illPerson,
+            TestData.Appeal.Reason.IllnessReason.otherPerson,
+            TestData.Appeal.Reason.IllnessReason.illnessStart,
+            TestData.Appeal.Reason.IllnessReason.continuedIllness,
+            TestData.Appeal.Reason.IllnessReason.illnessEnd,
+            TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation,
+            Lists.newArrayList(
+                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
+                    TestData.Appeal.Reason.Attachment.url)
+            ));
+    }
+
+    private OtherReason createOtherReason() {
+        return new OtherReason(TestData.Appeal.Reason.OtherReason.title, TestData.Appeal.Reason.OtherReason.description,
+            Lists.newArrayList(
+                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
+                    TestData.Appeal.Reason.Attachment.url),
+                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
@@ -2,19 +2,16 @@ package uk.gov.companieshouse.model.validator;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.companieshouse.util.TestUtil.createIllnessReason;
+import static uk.gov.companieshouse.util.TestUtil.createOtherReason;
 
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.exception.AppealReasonException;
-import uk.gov.companieshouse.model.Attachment;
-import uk.gov.companieshouse.model.IllnessReason;
-import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.model.Reason;
 
 @ExtendWith(SpringExtension.class)
@@ -47,30 +44,5 @@ class AppealReasonValidatorTest {
     void shouldNotThrowErrorWhenItsOtherReason(){
         mockReason = new Reason(createOtherReason(), null);
         assertDoesNotThrow(() -> appealReasonValidator.validate(mockReason));
-    }
-
-    private IllnessReason createIllnessReason(){
-        return new IllnessReason(
-            TestData.Appeal.Reason.IllnessReason.illPerson,
-            TestData.Appeal.Reason.IllnessReason.otherPerson,
-            TestData.Appeal.Reason.IllnessReason.illnessStart,
-            TestData.Appeal.Reason.IllnessReason.continuedIllness,
-            TestData.Appeal.Reason.IllnessReason.illnessEnd,
-            TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation,
-            Lists.newArrayList(
-                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
-                    TestData.Appeal.Reason.Attachment.url)
-            ));
-    }
-
-    private OtherReason createOtherReason() {
-        return new OtherReason(TestData.Appeal.Reason.OtherReason.title, TestData.Appeal.Reason.OtherReason.description,
-            Lists.newArrayList(
-                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
-                    TestData.Appeal.Reason.Attachment.url),
-                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.util.TestUtil.createIllnessReason;
+import static uk.gov.companieshouse.util.TestUtil.createOtherReason;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -34,11 +36,8 @@ import uk.gov.companieshouse.database.entity.ReasonEntity;
 import uk.gov.companieshouse.exception.ChipsServiceException;
 import uk.gov.companieshouse.mapper.AppealMapper;
 import uk.gov.companieshouse.model.Appeal;
-import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.model.ChipsContact;
 import uk.gov.companieshouse.model.CreatedBy;
-import uk.gov.companieshouse.model.IllnessReason;
-import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 import uk.gov.companieshouse.model.Reason;
 import uk.gov.companieshouse.model.ReasonType;
@@ -434,28 +433,6 @@ public class AppealServiceTest {
             + "\nFurther information: "
             + TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation
             + "\nSupporting documents: None";
-    }
-
-    private OtherReason createOtherReason() {
-        return new OtherReason(TestData.Appeal.Reason.OtherReason.title, TestData.Appeal.Reason.OtherReason.description,
-            Lists.newArrayList(
-                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
-                    TestData.Appeal.Reason.Attachment.url),
-                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
-    }
-
-    private IllnessReason createIllnessReason() {
-        return new IllnessReason(TestData.Appeal.Reason.IllnessReason.illPerson,
-            TestData.Appeal.Reason.IllnessReason.otherPerson, TestData.Appeal.Reason.IllnessReason.illnessStart,
-            TestData.Appeal.Reason.IllnessReason.continuedIllness, TestData.Appeal.Reason.IllnessReason.illnessEnd,
-            TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation, Lists.newArrayList(
-            new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
-                TestData.Appeal.Reason.Attachment.url),
-            new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
-                TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
     }
 
     private OtherReasonEntity createOtherReasonEntity() {

--- a/src/test/java/uk/gov/companieshouse/util/TestUtil.java
+++ b/src/test/java/uk/gov/companieshouse/util/TestUtil.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.util;
+
+import org.assertj.core.util.Lists;
+import uk.gov.companieshouse.TestData;
+import uk.gov.companieshouse.model.Attachment;
+import uk.gov.companieshouse.model.IllnessReason;
+import uk.gov.companieshouse.model.OtherReason;
+
+public class TestUtil {
+    public static IllnessReason createIllnessReason() {
+        return new IllnessReason(TestData.Appeal.Reason.IllnessReason.illPerson,
+            TestData.Appeal.Reason.IllnessReason.otherPerson, TestData.Appeal.Reason.IllnessReason.illnessStart,
+            TestData.Appeal.Reason.IllnessReason.continuedIllness, TestData.Appeal.Reason.IllnessReason.illnessEnd,
+            TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation, Lists.newArrayList(
+            new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
+                TestData.Appeal.Reason.Attachment.url),
+            new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
+    }
+
+    public static OtherReason createOtherReason() {
+        return new OtherReason(TestData.Appeal.Reason.OtherReason.title, TestData.Appeal.Reason.OtherReason.description,
+            Lists.newArrayList(
+                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size,
+                    TestData.Appeal.Reason.Attachment.url),
+                new Attachment(TestData.Appeal.Reason.Attachment.id, TestData.Appeal.Reason.Attachment.name,
+                    TestData.Appeal.Reason.Attachment.contentType, TestData.Appeal.Reason.Attachment.size, null)));
+    }
+}

--- a/src/test/resources/data/invalidAppealReason.json
+++ b/src/test/resources/data/invalidAppealReason.json
@@ -1,0 +1,23 @@
+  {
+    "penaltyIdentifier": {
+      "companyNumber": "12345678",
+      "penaltyReference": "A12345678"
+    },
+    "reasons": {
+      "other": {
+        "title": "This is a title",
+        "description": "This is a description"
+      },
+      "illnessReason": {
+        "illPerson": "ill Person",
+        "otherPerson": "other person",
+        "illnessStart": "01/01/2021",
+        "continuedIllness": false,
+        "illnessEnd": "01/02/2021",
+        "illnessImpactFurtherInformation": "further information"
+      }
+    },
+    "createdBy": {
+      "id": "123abc456"
+    }
+  }


### PR DESCRIPTION
Add validation to only allow Illness or Other reason to be submitted.

Resolves [BI-8452](https://companieshouse.atlassian.net/browse/BI-8452)