### PR TITLE
Refactor reasons mappers and related test

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/IllnessReasonMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/IllnessReasonMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.mapper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.model.IllnessReason;
 import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
@@ -10,11 +11,8 @@ import java.util.stream.Collectors;
 @Component
 public class IllnessReasonMapper implements Mapper<IllnessReasonEntity, IllnessReason> {
 
-    private final AttachmentMapper attachmentMapper;
-
-    public IllnessReasonMapper(AttachmentMapper attachmentMapper) {
-        this.attachmentMapper = attachmentMapper;
-    }
+    @Autowired
+    private AttachmentMapper attachmentMapper;
 
     public IllnessReasonEntity map(IllnessReason value) {
         if (value == null) {

--- a/src/main/java/uk/gov/companieshouse/mapper/OtherReasonMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/OtherReasonMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.mapper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
 import uk.gov.companieshouse.mapper.base.Mapper;
@@ -10,11 +11,8 @@ import java.util.stream.Collectors;
 @Component
 public class OtherReasonMapper implements Mapper<OtherReasonEntity, OtherReason> {
 
-    private final AttachmentMapper attachmentMapper;
-
-    public OtherReasonMapper(AttachmentMapper attachmentMapper) {
-        this.attachmentMapper = attachmentMapper;
-    }
+    @Autowired
+    private AttachmentMapper attachmentMapper;
 
     public OtherReasonEntity map(OtherReason value) {
         if (value == null) {

--- a/src/main/java/uk/gov/companieshouse/mapper/ReasonMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/ReasonMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.mapper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.database.entity.ReasonEntity;
 import uk.gov.companieshouse.mapper.base.Mapper;
@@ -8,13 +9,11 @@ import uk.gov.companieshouse.model.Reason;
 @Component
 public class ReasonMapper implements Mapper<ReasonEntity, Reason> {
 
-    private final OtherReasonMapper otherReasonMapper;
-    private final IllnessReasonMapper illnessReasonMapper;
+    @Autowired
+    private OtherReasonMapper otherReasonMapper;
 
-    public ReasonMapper(OtherReasonMapper otherReasonMapper, IllnessReasonMapper illnessReasonMapper) {
-        this.otherReasonMapper = otherReasonMapper;
-        this.illnessReasonMapper = illnessReasonMapper;
-    }
+    @Autowired
+    private IllnessReasonMapper illnessReasonMapper;
 
     @Override
     public ReasonEntity map(Reason value) {

--- a/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
@@ -2,10 +2,11 @@ package uk.gov.companieshouse.mapper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.companieshouse.model.IllnessReason;
 import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
-
 
 import java.util.Collections;
 
@@ -15,8 +16,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @ExtendWith(SpringExtension.class)
-    class IllnessReasonMapperTest {
-    private final IllnessReasonMapper mapper = new IllnessReasonMapper(new AttachmentMapper());
+class IllnessReasonMapperTest {
+
+    @Spy
+    private AttachmentMapper attachmentMapper;
+
+    @InjectMocks
+    private IllnessReasonMapper mapper;
+
     private final static String ILL_PERSON = "name";
     private final static String OTHER_PERSON = "otherPersonName";
     private final static String ILLNESS_START = "01/01/2021";
@@ -24,38 +31,37 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
     private final static String ILLNESS_END ="02/02/2021";
     private final static String FURTHER_INFORMATION ="furtherInformation";
 
+    @Test
+    void shouldReturnNullWhenValueIsNullReasonToEntity() {
+        assertNull(mapper.map((IllnessReason) null));
+    }
 
-        @Test
-        void shouldReturnNullWhenValueIsNullReasonToEntity() {
-            assertNull(mapper.map((IllnessReason) null));
-        }
+    @Test
+    void shouldMapValueWhenValueIsNotNullReasonToEntity() {
+        IllnessReasonEntity mapped = mapper.map(new IllnessReason(ILL_PERSON, OTHER_PERSON, ILLNESS_START, CONTINUED_ILLNESS, ILLNESS_END, FURTHER_INFORMATION, Collections.emptyList()));
+        assertEquals(ILL_PERSON, mapped.getIllPerson());
+        assertEquals(OTHER_PERSON, mapped.getOtherPerson());
+        assertEquals(ILLNESS_START, mapped.getIllnessStartDate());
+        assertEquals(CONTINUED_ILLNESS, mapped.getContinuedIllness());
+        assertEquals(ILLNESS_END, mapped.getIllnessEndDate());
+        assertEquals(FURTHER_INFORMATION, mapped.getIllnessImpactFurtherInformation());
+        assertTrue(mapped.getAttachments().isEmpty());
+    }
+    @Test
+    void shouldReturnNullWhenValueIsNullEntityToReason() {
+        assertNull(mapper.map((IllnessReasonEntity) null));
+    }
 
-        @Test
-        void shouldMapValueWhenValueIsNotNullReasonToEntity() {
-            IllnessReasonEntity mapped = mapper.map(new IllnessReason(ILL_PERSON, OTHER_PERSON, ILLNESS_START, CONTINUED_ILLNESS, ILLNESS_END, FURTHER_INFORMATION, Collections.emptyList()));
-            assertEquals(ILL_PERSON, mapped.getIllPerson());
-            assertEquals(OTHER_PERSON, mapped.getOtherPerson());
-            assertEquals(ILLNESS_START, mapped.getIllnessStartDate());
-            assertEquals(CONTINUED_ILLNESS, mapped.getContinuedIllness());
-            assertEquals(ILLNESS_END, mapped.getIllnessEndDate());
-            assertEquals(FURTHER_INFORMATION, mapped.getIllnessImpactFurtherInformation());
-            assertTrue(mapped.getAttachments().isEmpty());
-        }
-        @Test
-        void shouldReturnNullWhenValueIsNullEntityToReason() {
-            assertNull(mapper.map((IllnessReasonEntity) null));
-        }
-
-        @Test
-        void shouldMapValueWhenValueIsNotNullEntityToReason() {
-            IllnessReason mapped = mapper.map(new IllnessReasonEntity(ILL_PERSON, OTHER_PERSON, ILLNESS_START, CONTINUED_ILLNESS, ILLNESS_END, FURTHER_INFORMATION, Collections.emptyList()));
-            assertEquals(ILL_PERSON, mapped.getIllPerson());
-            assertEquals(OTHER_PERSON, mapped.getOtherPerson());
-            assertEquals(ILLNESS_START, mapped.getIllnessStart());
-            assertEquals(CONTINUED_ILLNESS, mapped.getContinuedIllness());
-            assertEquals(ILLNESS_END, mapped.getIllnessEnd());
-            assertEquals(FURTHER_INFORMATION, mapped.getIllnessImpactFurtherInformation());
-            assertTrue(mapped.getAttachments().isEmpty());
-        }
+    @Test
+    void shouldMapValueWhenValueIsNotNullEntityToReason() {
+        IllnessReason mapped = mapper.map(new IllnessReasonEntity(ILL_PERSON, OTHER_PERSON, ILLNESS_START, CONTINUED_ILLNESS, ILLNESS_END, FURTHER_INFORMATION, Collections.emptyList()));
+        assertEquals(ILL_PERSON, mapped.getIllPerson());
+        assertEquals(OTHER_PERSON, mapped.getOtherPerson());
+        assertEquals(ILLNESS_START, mapped.getIllnessStart());
+        assertEquals(CONTINUED_ILLNESS, mapped.getContinuedIllness());
+        assertEquals(ILLNESS_END, mapped.getIllnessEnd());
+        assertEquals(FURTHER_INFORMATION, mapped.getIllnessImpactFurtherInformation());
+        assertTrue(mapped.getAttachments().isEmpty());
+    }
 }
 

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -3,6 +3,8 @@ package uk.gov.companieshouse.mapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
 import uk.gov.companieshouse.model.OtherReason;
@@ -17,7 +19,12 @@ import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.title;
 
 @ExtendWith(SpringExtension.class)
 public class OtherReasonMapperTest {
-    private final OtherReasonMapper mapper = new OtherReasonMapper(new AttachmentMapper());
+
+    @Spy
+    private AttachmentMapper attachmentMapper;
+
+    @InjectMocks
+    private OtherReasonMapper mapper;
 
     @Nested
     class ToEntityMappingTest {

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -16,7 +16,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.description;
 import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.title;
 
@@ -47,11 +49,13 @@ public class OtherReasonMapperTest {
             List<Attachment> attachments = new ArrayList<Attachment>();
             attachments.add(mockAttachment);
 
+            when(attachmentMapper.map(any(Attachment.class))).thenReturn(mockAttachmentEntity);
+
             OtherReasonEntity mapped = mapper.map(new OtherReason(title, description, attachments));
 
             assertEquals(title, mapped.getTitle());
             assertEquals(description, mapped.getDescription());
-            assertEquals(mockAttachment, attachments.get(0));
+            assertEquals(mockAttachmentEntity, mapped.getAttachments().get(0));
 
             verify(attachmentMapper).map(attachments.get(0));
         }
@@ -69,11 +73,13 @@ public class OtherReasonMapperTest {
             List<AttachmentEntity> attachmentEntities = new ArrayList<AttachmentEntity>();
             attachmentEntities.add(mockAttachmentEntity);
 
+            when(attachmentMapper.map(any(AttachmentEntity.class))).thenReturn(mockAttachment);
+
             OtherReason mapped = mapper.map(new OtherReasonEntity(title, description, attachmentEntities));
 
             assertEquals(title, mapped.getTitle());
             assertEquals(description, mapped.getDescription());
-            assertEquals(mockAttachmentEntity, attachmentEntities.get(0));
+            assertEquals(mockAttachment, mapped.getAttachments().get(0));
 
             verify(attachmentMapper).map(attachmentEntities.get(0));
         }

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -4,24 +4,33 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Spy;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.companieshouse.database.entity.AttachmentEntity;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
+import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.model.OtherReason;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.description;
 import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.title;
 
 @ExtendWith(SpringExtension.class)
 public class OtherReasonMapperTest {
 
-    @Spy
+    @Mock
     private AttachmentMapper attachmentMapper;
+
+    @Mock
+    private Attachment mockAttachment;
+
+    @Mock
+    private AttachmentEntity mockAttachmentEntity;
 
     @InjectMocks
     private OtherReasonMapper mapper;
@@ -35,10 +44,16 @@ public class OtherReasonMapperTest {
 
         @Test
         void shouldMapValueWhenValueIsNotNull() {
-            OtherReasonEntity mapped = mapper.map(new OtherReason(title, description, Collections.emptyList()));
+            List<Attachment> attachments = new ArrayList<Attachment>();
+            attachments.add(mockAttachment);
+
+            OtherReasonEntity mapped = mapper.map(new OtherReason(title, description, attachments));
+
             assertEquals(title, mapped.getTitle());
             assertEquals(description, mapped.getDescription());
-            assertTrue(mapped.getAttachments().isEmpty());
+            assertEquals(mockAttachment, attachments.get(0));
+
+            verify(attachmentMapper).map(attachments.get(0));
         }
     }
 
@@ -51,10 +66,16 @@ public class OtherReasonMapperTest {
 
         @Test
         void shouldMapValueWhenValueIsNotNull() {
-            OtherReason mapped = mapper.map(new OtherReasonEntity(title, description, Collections.emptyList()));
+            List<AttachmentEntity> attachmentEntities = new ArrayList<AttachmentEntity>();
+            attachmentEntities.add(mockAttachmentEntity);
+
+            OtherReason mapped = mapper.map(new OtherReasonEntity(title, description, attachmentEntities));
+
             assertEquals(title, mapped.getTitle());
             assertEquals(description, mapped.getDescription());
-            assertTrue(mapped.getAttachments().isEmpty());
+            assertEquals(mockAttachmentEntity, attachmentEntities.get(0));
+
+            verify(attachmentMapper).map(attachmentEntities.get(0));
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
@@ -2,20 +2,14 @@ package uk.gov.companieshouse.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.continuedIllness;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.illPerson;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.illnessEnd;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.illnessImpactFurtherInformation;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.illnessStart;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.IllnessReason.otherPerson;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.description;
-import static uk.gov.companieshouse.TestData.Appeal.Reason.OtherReason.title;
-import static uk.gov.companieshouse.util.TestUtil.createIllnessReason;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
@@ -26,8 +20,24 @@ import uk.gov.companieshouse.model.Reason;
 
 @ExtendWith(SpringExtension.class)
 class ReasonMapperTest {
-    private final ReasonMapper mapper = new ReasonMapper(new OtherReasonMapper(new AttachmentMapper()),
-        new IllnessReasonMapper(new AttachmentMapper()));
+
+    @Mock
+    private OtherReasonMapper otherReasonMapper;
+    @Mock
+    private OtherReasonEntity otherReasonEntity;
+
+    @Mock
+    private IllnessReasonMapper illnessReasonMapper;
+    @Mock
+    private IllnessReasonEntity illnessReasonEntity;
+
+    @InjectMocks
+    private ReasonMapper mapper;
+
+    @Mock
+    private IllnessReason mockIllnessReason;
+    @Mock
+    private OtherReason mockOtherReason;
 
     @Nested
     class ToEntityMappingTest {
@@ -38,21 +48,17 @@ class ReasonMapperTest {
 
         @Test
         void shouldMapValueWhenValueIsNotNull() {
+            when(illnessReasonMapper.map(any(IllnessReason.class))).thenReturn(illnessReasonEntity);
+            when(otherReasonMapper.map(any(OtherReason.class))).thenReturn(otherReasonEntity);
+
             Reason reason = new Reason();
-            reason.setIllnessReason(new IllnessReason(illPerson, otherPerson, illnessStart, continuedIllness,
-                illnessEnd, illnessImpactFurtherInformation, Collections.emptyList()));
-            reason.setOther(new OtherReason(title, description, Collections.emptyList()));
+            reason.setOther(mockOtherReason);
+            reason.setIllnessReason(mockIllnessReason);
 
             ReasonEntity mapped = mapper.map(reason);
-            assertEquals(title, mapped.getOther().getTitle());
-            assertEquals(description, mapped.getOther().getDescription());
-            assertEquals(illPerson, mapped.getIllnessReason().getIllPerson());
-            assertEquals(otherPerson, mapped.getIllnessReason().getOtherPerson());
-            assertEquals(illnessStart, mapped.getIllnessReason().getIllnessStartDate());
-            assertEquals(continuedIllness, mapped.getIllnessReason().getContinuedIllness());
-            assertEquals(illnessEnd, mapped.getIllnessReason().getIllnessEndDate());
-            assertEquals(illnessImpactFurtherInformation,
-                mapped.getIllnessReason().getIllnessImpactFurtherInformation());
+
+            assertEquals(illnessReasonEntity, mapped.getIllnessReason());
+            assertEquals(otherReasonEntity, mapped.getOther());
         }
     }
 
@@ -65,21 +71,18 @@ class ReasonMapperTest {
 
         @Test
         void shouldMapValueWhenValueIsNotNull() {
+            when(illnessReasonMapper.map(any(IllnessReasonEntity.class))).thenReturn(mockIllnessReason);
+            when(otherReasonMapper.map(any(OtherReasonEntity.class))).thenReturn(mockOtherReason);
+
             ReasonEntity reasonEntity = new ReasonEntity();
-            reasonEntity.setIllnessReason(new IllnessReasonEntity(illPerson, otherPerson, illnessStart,
-                continuedIllness, illnessEnd, illnessImpactFurtherInformation, Collections.emptyList()));
-            reasonEntity.setOther(new OtherReasonEntity(title, description, Collections.emptyList()));
+
+            reasonEntity.setIllnessReason(illnessReasonEntity);
+            reasonEntity.setOther(otherReasonEntity);
 
             Reason mapped = mapper.map(reasonEntity);
-            assertEquals(title, mapped.getOther().getTitle());
-            assertEquals(description, mapped.getOther().getDescription());
-            assertEquals(illPerson, mapped.getIllnessReason().getIllPerson());
-            assertEquals(otherPerson, mapped.getIllnessReason().getOtherPerson());
-            assertEquals(illnessStart, mapped.getIllnessReason().getIllnessStart());
-            assertEquals(continuedIllness, mapped.getIllnessReason().getContinuedIllness());
-            assertEquals(illnessEnd, mapped.getIllnessReason().getIllnessEnd());
-            assertEquals(illnessImpactFurtherInformation,
-                mapped.getIllnessReason().getIllnessImpactFurtherInformation());
+
+            assertEquals(mockIllnessReason, mapped.getIllnessReason());
+            assertEquals(mockOtherReason, mapped.getOther());
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Nested;
@@ -59,6 +60,9 @@ class ReasonMapperTest {
 
             assertEquals(illnessReasonEntity, mapped.getIllnessReason());
             assertEquals(otherReasonEntity, mapped.getOther());
+
+            verify(illnessReasonMapper).map(mockIllnessReason);
+            verify(otherReasonMapper).map(mockOtherReason);
         }
     }
 
@@ -83,6 +87,9 @@ class ReasonMapperTest {
 
             assertEquals(mockIllnessReason, mapped.getIllnessReason());
             assertEquals(mockOtherReason, mapped.getOther());
+
+            verify(illnessReasonMapper).map(illnessReasonEntity);
+            verify(otherReasonMapper).map(otherReasonEntity);
         }
     }
 }


### PR DESCRIPTION
Related to [BI-8307](https://companieshouse.atlassian.net/browse/BI-8307)
- Refactor all Reason mapper - switched to use setters instead of a constructor
- Refactor AppealMapperTest