### PR TITLE
Replace SpringExtension with MockitoExtension

### DIFF
--- a/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.database.entity.AppealEntity;
 import uk.gov.companieshouse.database.entity.CreatedByEntity;
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.model.CreatedBy;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class AppealMapperTest {
     @Mock
     private ReasonMapper reasonMapper;

--- a/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.model.PenaltyIdentifier;
 import uk.gov.companieshouse.model.Reason;
 
 @ExtendWith(MockitoExtension.class)
-public class AppealMapperTest {
+class AppealMapperTest {
     @Mock
     private ReasonMapper reasonMapper;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AppealMapperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,11 +51,14 @@ class AppealMapperTest {
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((Appeal) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             when(createdByMapper.map(any(CreatedBy.class))).thenReturn(null);
@@ -83,11 +87,14 @@ class AppealMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((AppealEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             when(createdByMapper.map(any(CreatedByEntity.class))).thenReturn(mockCreatedBy);

--- a/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
@@ -13,7 +13,7 @@ import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.TestUtil;
 
 @ExtendWith(MockitoExtension.class)
-public class AttachmentMapperTest {
+class AttachmentMapperTest {
     private final AttachmentMapper mapper = new AttachmentMapper();
 
     @Nested

--- a/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,11 +19,14 @@ class AttachmentMapperTest {
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((Attachment) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             AttachmentEntity mapped = mapper.map(TestUtil.createAttachment());
@@ -36,11 +40,14 @@ class AttachmentMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((AttachmentEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             Attachment mapped = mapper.map(TestUtil.createAttachmentEntity());

--- a/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/AttachmentMapperTest.java
@@ -6,13 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.database.entity.AttachmentEntity;
 import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.TestUtil;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class AttachmentMapperTest {
     private final AttachmentMapper mapper = new AttachmentMapper();
 

--- a/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
@@ -13,7 +13,7 @@ import uk.gov.companieshouse.database.entity.CreatedByEntity;
 import uk.gov.companieshouse.model.CreatedBy;
 
 @ExtendWith(MockitoExtension.class)
-public class CreatedByMapperTest {
+class CreatedByMapperTest {
     private final CreatedByMapper mapper = new CreatedByMapper();
 
     @Nested

--- a/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,11 +19,14 @@ class CreatedByMapperTest {
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((CreatedBy) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             CreatedBy createdBy = TestUtil.buildCreatedBy();
@@ -33,11 +37,14 @@ class CreatedByMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is not null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((CreatedByEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             CreatedByEntity createdByEntity = new CreatedByEntity();

--- a/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/CreatedByMapperTest.java
@@ -6,13 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.TestUtil;
 import uk.gov.companieshouse.database.entity.CreatedByEntity;
 import uk.gov.companieshouse.model.CreatedBy;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class CreatedByMapperTest {
     private final CreatedByMapper mapper = new CreatedByMapper();
 

--- a/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
@@ -7,14 +7,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
 import uk.gov.companieshouse.model.IllnessReason;
 import uk.gov.companieshouse.TestUtil;
 
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class IllnessReasonMapperTest {
 
     @Spy

--- a/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/IllnessReasonMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,11 +24,13 @@ class IllnessReasonMapperTest {
     @InjectMocks
     private IllnessReasonMapper mapper;
 
+    @DisplayName("Should return null when value is null reason to entity")
     @Test
     void shouldReturnNullWhenValueIsNullReasonToEntity() {
         assertNull(mapper.map((IllnessReason) null));
     }
 
+    @DisplayName("Should map value when value is not null reason to entity")
     @Test
     void shouldMapValueWhenValueIsNotNullReasonToEntity() {
 
@@ -47,11 +50,13 @@ class IllnessReasonMapperTest {
 
     }
 
+    @DisplayName("Should return null when valuse is null entity to reason")
     @Test
     void shouldReturnNullWhenValueIsNullEntityToReason() {
         assertNull(mapper.map((IllnessReasonEntity) null));
     }
 
+    @DisplayName("Should map value when value is not null entity to reason")
     @Test
     void shouldMapValueWhenValueIsNotNullEntityToReason() {
         IllnessReason mapped = mapper.map(TestUtil.createIllnessReasonEntity());

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.TestUtil;
 
 @ExtendWith(MockitoExtension.class)
-public class OtherReasonMapperTest {
+class OtherReasonMapperTest {
 
     @Mock
     private AttachmentMapper attachmentMapper;

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,11 +36,14 @@ class OtherReasonMapperTest {
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((OtherReason) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
 
@@ -59,11 +63,14 @@ class OtherReasonMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((OtherReasonEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
 

--- a/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/OtherReasonMapperTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.database.entity.AttachmentEntity;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
@@ -18,7 +18,7 @@ import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.TestUtil;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class OtherReasonMapperTest {
 
     @Mock

--- a/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.database.entity.PenaltyIdentifierEntity;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class PenaltyIdentifierMapperTest {
     private final PenaltyIdentifierMapper mapper = new PenaltyIdentifierMapper();
 

--- a/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,15 +14,19 @@ import uk.gov.companieshouse.model.PenaltyIdentifier;
 
 @ExtendWith(MockitoExtension.class)
 class PenaltyIdentifierMapperTest {
+
     private final PenaltyIdentifierMapper mapper = new PenaltyIdentifierMapper();
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((PenaltyIdentifier) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             PenaltyIdentifierEntity mapped = mapper.map(new PenaltyIdentifier(TestData.COMPANY_NUMBER, TestData.PENALTY_REFERENCE));
@@ -32,11 +37,14 @@ class PenaltyIdentifierMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((PenaltyIdentifierEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             PenaltyIdentifier mapped = mapper.map(new PenaltyIdentifierEntity(TestData.COMPANY_NUMBER, TestData.PENALTY_REFERENCE));

--- a/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/PenaltyIdentifierMapperTest.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.database.entity.PenaltyIdentifierEntity;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 
 @ExtendWith(MockitoExtension.class)
-public class PenaltyIdentifierMapperTest {
+class PenaltyIdentifierMapperTest {
     private final PenaltyIdentifierMapper mapper = new PenaltyIdentifierMapper();
 
     @Nested

--- a/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
 import uk.gov.companieshouse.database.entity.ReasonEntity;
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.model.IllnessReason;
 import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class ReasonMapperTest {
 
     @Mock

--- a/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/ReasonMapperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,11 +43,14 @@ class ReasonMapperTest {
 
     @Nested
     class ToEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((Reason) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             when(illnessReasonMapper.map(any(IllnessReason.class))).thenReturn(illnessReasonEntity);
@@ -68,11 +72,14 @@ class ReasonMapperTest {
 
     @Nested
     class FromEntityMappingTest {
+
+        @DisplayName("Should return null when value is null")
         @Test
         void shouldReturnNullWhenValueIsNull() {
             assertNull(mapper.map((ReasonEntity) null));
         }
 
+        @DisplayName("Should map value when value is not null")
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             when(illnessReasonMapper.map(any(IllnessReasonEntity.class))).thenReturn(mockIllnessReason);

--- a/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
@@ -7,47 +7,41 @@ import static uk.gov.companieshouse.TestUtil.createOtherReason;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-
-import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(MockitoExtension.class)
 class AppealReasonValidatorTest {
 
-    @InjectMocks
-    private AppealReasonValidator appealReasonValidator;
+    private AppealReasonValidator appealReasonValidator = new AppealReasonValidator();;
 
     @DisplayName("Validation failure for no Appeal reasons")
     @Test
     void shouldReturnFalseWhenItsNotIllnessOrOtherReason() {
-        Reason mockReason = new Reason();
-        assertEquals("Other/Illness must be supplied with an Appeal",appealReasonValidator.validate(mockReason));
+        Reason reason = new Reason();
+        assertEquals("Other/Illness must be supplied with an Appeal",appealReasonValidator.validate(reason));
     }
 
     @DisplayName("Validation failure for more than one Appeal reason")
     @Test
     void shouldReturnFalseWhenHasBothIllnessAndOtherReason() {
-        Reason mockReason = new Reason();
-        mockReason.setIllness(createIllnessReason());
-        mockReason.setOther(createOtherReason());
-        assertEquals("Only one reason type can be supplied with an Appeal",appealReasonValidator.validate(mockReason));
+        Reason reason = new Reason();
+        reason.setIllness(createIllnessReason());
+        reason.setOther(createOtherReason());
+        assertEquals("Only one reason type can be supplied with an Appeal",appealReasonValidator.validate(reason));
     }
 
     @DisplayName("Validation success for illness Appeal reason only")
     @Test
     void shouldReturnTrueWhenItsIllnessReason(){
-        Reason mockReason = new Reason();
-        mockReason.setIllness(createIllnessReason());
-        assertNull(appealReasonValidator.validate(mockReason));
+        Reason reason = new Reason();
+        reason.setIllness(createIllnessReason());
+        assertNull(appealReasonValidator.validate(reason));
     }
 
     @DisplayName("Validation success for other Appeal reason only")
     @Test
     void shouldReturnTrueWhenWhenItsOtherReason(){
-        Reason mockReason = new Reason();
-        mockReason.setOther(createOtherReason());
-        assertNull(appealReasonValidator.validate(mockReason));
+        Reason reason = new Reason();
+        reason.setOther(createOtherReason());
+        assertNull(appealReasonValidator.validate(reason));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class AppealReasonValidatorTest {
 
     @InjectMocks

--- a/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/AppealReasonValidatorTest.java
@@ -5,13 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.companieshouse.TestUtil.createIllnessReason;
 import static uk.gov.companieshouse.TestUtil.createOtherReason;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.model.Reason;
 
 class AppealReasonValidatorTest {
 
-    private AppealReasonValidator appealReasonValidator = new AppealReasonValidator();;
+    private AppealReasonValidator appealReasonValidator;
+
+    @BeforeEach
+    private void setup() {
+        appealReasonValidator = new AppealReasonValidator();
+    }
 
     @DisplayName("Validation failure for no Appeal reasons")
     @Test

--- a/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
@@ -11,10 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 public class CompanyNumberValidatorTest {
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
@@ -10,10 +10,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class CompanyNumberValidatorTest {
 
+    @DisplayName("Throw an exception when input list is in wrong format")
     @Test
     void shouldThrowAnExceptionWhenInputListIsInWrongFormat() {
 
@@ -24,12 +26,14 @@ class CompanyNumberValidatorTest {
 
     }
 
+    @DisplayName("Create factory successfully when valid lists are provided")
     @Test
-    void shouldCreateFactorySuccessfulyWhenValidListsProvided() {
+    void shouldCreateFactorySuccessfullyWhenValidListsProvided() {
         List<String> validLists = List.of("NI", "AB,CD,EF", "A,B,C,D,F", "AB,cd,e,F");
         validLists.forEach(prefixList -> assertDoesNotThrow(() -> new CompanyNumberValidator(prefixList), prefixList));
     }
 
+    @DisplayName("Return false when prefix is not allowed")
     @Test
     void shouldReturnFalseWhenPrefixIsNotAllowed() {
         String prefixes = "SC,NI,OC,SO,R,AP";
@@ -45,6 +49,7 @@ class CompanyNumberValidatorTest {
 
     }
 
+    @DisplayName("Return true when prefixes are allowed")
     @Test
     void shouldReturnTrueWhenPrefixesAreAllowed() {
         String prefixes = "SC,NI,OC,SO,R,AP";
@@ -64,6 +69,7 @@ class CompanyNumberValidatorTest {
 
     }
 
+    @DisplayName("Return false when value is null")
     @Test
     void shouldReturnFalseWhenValueIsNull() {
         assertFalse(new CompanyNumberValidator("A,B,C").isValid(null, null));

--- a/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/CompanyNumberValidatorTest.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-public class CompanyNumberValidatorTest {
+class CompanyNumberValidatorTest {
 
     @Test
     void shouldThrowAnExceptionWhenInputListIsInWrongFormat() {

--- a/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.TestUtil;
 import uk.gov.companieshouse.model.Appeal;

--- a/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
@@ -6,14 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.TestUtil;
 import uk.gov.companieshouse.model.Appeal;
 import uk.gov.companieshouse.model.CreatedBy;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class RelationshipValidatorTest {
 
     @InjectMocks

--- a/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.model.validator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.TestData;
@@ -13,7 +14,12 @@ import uk.gov.companieshouse.model.Reason;
 
 class RelationshipValidatorTest {
 
-    private RelationshipValidator relationshipValidator = new RelationshipValidator();
+    private RelationshipValidator relationshipValidator;
+
+    @BeforeEach
+    private void setup() {
+        relationshipValidator = new RelationshipValidator();
+    }
 
     private Appeal createTestIllnessAppeal() {
         CreatedBy createdBy = TestUtil.buildCreatedBy();

--- a/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/model/validator/RelationshipValidatorTest.java
@@ -3,65 +3,58 @@ package uk.gov.companieshouse.model.validator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.TestData;
 import uk.gov.companieshouse.TestUtil;
 import uk.gov.companieshouse.model.Appeal;
 import uk.gov.companieshouse.model.CreatedBy;
 import uk.gov.companieshouse.model.Reason;
 
-@ExtendWith(MockitoExtension.class)
 class RelationshipValidatorTest {
 
-    @InjectMocks
-    RelationshipValidator relationshipValidator;
+    private RelationshipValidator relationshipValidator = new RelationshipValidator();
 
     private Appeal createTestIllnessAppeal() {
-        CreatedBy mockCreated = TestUtil.buildCreatedBy();
+        CreatedBy createdBy = TestUtil.buildCreatedBy();
         Reason reason = new Reason();
         reason.setIllness(TestUtil.createIllnessReason());
-        Appeal mockAppeal = TestUtil.createAppeal(mockCreated, reason);
+        Appeal appeal = TestUtil.createAppeal(createdBy, reason);
 
-        return mockAppeal;
+        return appeal;
     }
 
     private Appeal createTestOtherAppeal() {
-        CreatedBy mockCreated = TestUtil.buildCreatedBy();
+        CreatedBy createdBy = TestUtil.buildCreatedBy();
         Reason reason = new Reason();
         reason.setOther(TestUtil.createOtherReason());
-        Appeal mockAppeal = TestUtil.createAppeal(mockCreated, reason);
+        Appeal appeal = TestUtil.createAppeal(createdBy, reason);
 
-        return mockAppeal;
+        return appeal;
     }
 
-    @Test
-    void shouldMakeRelationshipNullWhenRelationshipAndIllnessExist(){
-        Appeal mockAppeal = createTestIllnessAppeal();
-        relationshipValidator.validateRelationship(mockAppeal);
-        assertNull(mockAppeal.getCreatedBy().getRelationshipToCompany());
-    }
-
+    @DisplayName("Should return string if relationship is null with other reason")
     @Test
     void shouldReturnStringIfRelationshipIsNullWithOtherReason(){
-        Appeal mockAppeal = createTestOtherAppeal();
-        mockAppeal.getCreatedBy().setRelationshipToCompany(null);
+        Appeal appeal = createTestOtherAppeal();
+        appeal.getCreatedBy().setRelationshipToCompany(null);
         assertEquals(TestData.RELATIONSHIP_ERROR_MESSAGE,
-            relationshipValidator.validateRelationship(mockAppeal));
+            relationshipValidator.validateRelationship(appeal));
     }
 
+    @DisplayName("Should return null if relationship is not null with other reason")
     @Test
     void shouldReturnNullIfRelationshipIsNotNullWithOtherReason(){
-        Appeal mockAppeal = createTestOtherAppeal();
-        assertNull(relationshipValidator.validateRelationship(mockAppeal));
+        Appeal appeal = createTestOtherAppeal();
+        assertNull(relationshipValidator.validateRelationship(appeal));
     }
 
+    @DisplayName("Should return null if relationship is null with illness reason")
     @Test
     void shouldReturnNullIfRelationshipIsNullWithIllnessReason(){
-        Appeal mockAppeal = createTestIllnessAppeal();
-        assertNull(relationshipValidator.validateRelationship(mockAppeal));
+        Appeal appeal = createTestIllnessAppeal();
+        assertNull(relationshipValidator.validateRelationship(appeal));
     }
 
 }


### PR DESCRIPTION
Replace SpringExtension with MockitoExtension in mapper and model validation unit test classes

### JIRA link
Resolves: [BI-8683](https://companieshouse.atlassian.net/browse/BI-8683)


### Change description
Replace SpringExtension with MockitoExtension in mapper and model validation unit test classes

### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__