### PR TITLE
Add sending an email via kafka to API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,11 @@
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <avro.version>1.8.1</avro.version>
         <rest-service-common-library.version>0.0.5</rest-service-common-library.version>
-        <api-sdk-java-version>4.3.8</api-sdk-java-version>
-        <api-sdk-manager-java-library-version>1.0.4</api-sdk-manager-java-library-version>
+        <api-sdk-java.version>4.3.8</api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.94</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <environment-reader-library.version>1.3.8</environment-reader-library.version>
+        <httpclient.version>4.5.13</httpclient.version>
     </properties>
 
     <repositories>
@@ -94,6 +96,24 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>environment-reader-library</artifactId>
             <version>${environment-reader-library.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>${api-sdk-manager-java-library.version}</version>
+        </dependency>
+
+	    <dependency>
+	        <groupId>uk.gov.companieshouse</groupId>
+	        <artifactId>private-api-sdk-java</artifactId>
+	        <version>${private-api-sdk-java.version}</version>
+	    </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
         <commons-lang3.version>3.10</commons-lang3.version>
         <structured-logging.version>1.5.0-rc2</structured-logging.version>
         <kafka-models.version>1.0.17</kafka-models.version>
-        <ch-kafka.version>1.4.2</ch-kafka.version>
+        <ch-kafka.version>1.4.4</ch-kafka.version>
+        <avro.version>1.8.1</avro.version>
         <rest-service-common-library.version>0.0.5</rest-service-common-library.version>
         <api-sdk-java-version>4.3.8</api-sdk-java-version>
         <api-sdk-manager-java-library-version>1.0.4</api-sdk-manager-java-library-version>
@@ -81,23 +82,11 @@
             <artifactId>ch-kafka</artifactId>
             <version>${ch-kafka.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-manager-java-library</artifactId>
-            <version>${api-sdk-manager-java-library-version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-java</artifactId>
-            <version>${api-sdk-java-version}</version>
-        </dependency>
         
         <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>rest-service-common-library</artifactId>
-            <version>${rest-service-common-library.version}</version>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions -->
-        <version.spring.boot>2.4.0</version.spring.boot>
+        <version.spring.boot>2.4.3</version.spring.boot>
         <commons-lang3.version>3.10</commons-lang3.version>
         <structured-logging.version>1.5.0-rc2</structured-logging.version>
         <kafka-models.version>1.0.17</kafka-models.version>
@@ -30,6 +30,7 @@
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <environment-reader-library.version>1.3.8</environment-reader-library.version>
         <httpclient.version>4.5.13</httpclient.version>
+        <spring-kafka-test.version>2.7.7</spring-kafka-test.version>
     </properties>
 
     <repositories>
@@ -121,6 +122,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${version.spring.boot}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <version>${spring-kafka-test.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>lfp-appeals-api</artifactId>
-    <version>0.0.1</version>
+    <version>unversioned</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -21,6 +21,11 @@
         <version.spring.boot>2.4.0</version.spring.boot>
         <commons-lang3.version>3.10</commons-lang3.version>
         <structured-logging.version>1.5.0-rc2</structured-logging.version>
+        <kafka-models.version>1.0.17</kafka-models.version>
+        <ch-kafka.version>1.4.2</ch-kafka.version>
+        <rest-service-common-library.version>0.0.5</rest-service-common-library.version>
+        <api-sdk-java-version>4.3.8</api-sdk-java-version>
+        <api-sdk-manager-java-library-version>1.0.4</api-sdk-manager-java-library-version>
     </properties>
 
     <repositories>
@@ -63,6 +68,36 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>kafka-models</artifactId>
+            <version>${kafka-models.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>ch-kafka</artifactId>
+            <version>${ch-kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>${api-sdk-manager-java-library-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-java</artifactId>
+            <version>${api-sdk-java-version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>rest-service-common-library</artifactId>
+            <version>${rest-service-common-library.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <rest-service-common-library.version>0.0.5</rest-service-common-library.version>
         <api-sdk-java-version>4.3.8</api-sdk-java-version>
         <api-sdk-manager-java-library-version>1.0.4</api-sdk-manager-java-library-version>
+        <environment-reader-library.version>1.3.8</environment-reader-library.version>
     </properties>
 
     <repositories>
@@ -87,6 +88,12 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>environment-reader-library</artifactId>
+            <version>${environment-reader-library.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/uk/gov/companieshouse/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/ApplicationConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+
+@Configuration
+public class ApplicationConfig implements WebMvcConfigurer {
+
+    @Bean
+    SerializerFactory serializerFactory() {
+        return new SerializerFactory();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/controller/AppealController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/AppealController.java
@@ -108,7 +108,7 @@ public class AppealController {
     public ResponseEntity<Appeal> getAppealById(@PathVariable("company-number") final String companyId,
                                                 @PathVariable("id") final String id) {
 
-        LOGGER.infoContext("Getting Appeal by ID", companyId, appealService.createDebugMapWithoutAppeal(id));
+        LOGGER.infoContext("Getting Appeal by ID ", companyId, appealService.createDebugMapWithoutAppeal(id));
         final Optional<Appeal> appeal = appealService.getAppeal(id);
 
         return appeal.map(a -> ResponseEntity.status(HttpStatus.OK).body(a))
@@ -119,7 +119,7 @@ public class AppealController {
     public ResponseEntity<List<Appeal>> getAppealsByPenaltyReference(@PathVariable("company-number") final String companyId,
                                                               @RequestParam(value="penaltyReference") final String penaltyReference) {
 
-        LOGGER.info("Getting Appeal by PenaltyReference" +  companyId + " with reference: " + penaltyReference);
+        LOGGER.info("Getting Appeal by PenaltyReference " +  companyId + " with reference: " + penaltyReference);
         final List<Appeal> appealList = appealService.getAppealsByPenaltyReference(penaltyReference);
 
         if (appealList.isEmpty()){

--- a/src/main/java/uk/gov/companieshouse/email/EmailSend.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSend.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.email;
+
+import email.email_send;
+
+/**
+ * Extends {@link email_send} to make it available as an apparently Java naming and packaging conventions compliant
+ * class without requiring changes to the Avro schema from which <code>email_send</code> is generated.
+ */
+public class EmailSend extends email_send {
+}

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendKafkaProducer.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.email;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -19,18 +21,20 @@ public class EmailSendKafkaProducer extends KafkaProducer  {
 
     /**
      * Sends message to Kafka topic
-     * @param message certificate or certified copy appeal message to be produced to the <code>email-send</code> topic
-     * @param orderReference the reference of the order
+     * @param message Appeal message to be produced to the <code>email-send</code> topic
+     * @param penaltyReference The reference of the penalty
      * @param asyncResponseLogger RecordMetadata {@link Consumer} that can be implemented to allow the logging of
      *                            the offset once the message has been produced
      * @throws ExecutionException should the production of the message to the topic error for some reason
      * @throws InterruptedException should the execution thread be interrupted
      */
     public void sendMessage(final Message message,
-                            final String orderReference,
+                            final String penaltyReference,
                             final Consumer<RecordMetadata> asyncResponseLogger)
             throws ExecutionException, InterruptedException {
-        LOGGER.info("Sending message to Kafka");
+        Map<String, Object> logMap = new HashMap<>();
+    	logMap.put("message", message.toString());
+        LOGGER.infoContext(penaltyReference, "Sending message to Kafka", logMap);
 
         final Future<RecordMetadata> recordMetadataFuture = getChKafkaProducer().sendAndReturnFuture(message);
         asyncResponseLogger.accept(recordMetadataFuture.get());

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendKafkaProducer.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.email;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class EmailSendKafkaProducer extends KafkaProducer  {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    /**
+     * Sends message to Kafka topic
+     * @param message certificate or certified copy appeal message to be produced to the <code>email-send</code> topic
+     * @param orderReference the reference of the order
+     * @param asyncResponseLogger RecordMetadata {@link Consumer} that can be implemented to allow the logging of
+     *                            the offset once the message has been produced
+     * @throws ExecutionException should the production of the message to the topic error for some reason
+     * @throws InterruptedException should the execution thread be interrupted
+     */
+    public void sendMessage(final Message message,
+                            final String orderReference,
+                            final Consumer<RecordMetadata> asyncResponseLogger)
+            throws ExecutionException, InterruptedException {
+        LOGGER.info("Sending message to Kafka");
+
+        final Future<RecordMetadata> recordMetadataFuture = getChKafkaProducer().sendAndReturnFuture(message);
+        asyncResponseLogger.accept(recordMetadataFuture.get());
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendMessageFactory.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendMessageFactory.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.email;
+
+
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class EmailSendMessageFactory {
+
+	private final SerializerFactory serializerFactory;
+	private static final String EMAIL_SEND_TOPIC = "email-send";
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    public EmailSendMessageFactory(SerializerFactory serializer) {
+		serializerFactory = serializer;
+	}
+
+	/**
+	 * Creates an email-send avro message.
+	 * @param emailSend email-send object
+	 * @return email-send avro message
+	 * @throws SerializationException should there be a failure to serialize the EmailSend object
+	 */
+	public Message createMessage(final EmailSend emailSend, String orderReference) throws SerializationException {
+        //Map<String, Object> logMap = LoggingUtils.createLogMapWithOrderReference(orderReference);
+//	    logMap.put(LoggingUtils.TOPIC, EMAIL_SEND_TOPIC);
+//		LoggingUtils.getLogger().info("Create kafka message", logMap);
+        LOGGER.info("Create kafka message");
+		final AvroSerializer<EmailSend> serializer =
+				serializerFactory.getGenericRecordSerializer(EmailSend.class);
+		final Message message = new Message();
+		message.setValue(serializer.toBinary(emailSend));
+		message.setTopic(EMAIL_SEND_TOPIC);
+		message.setTimestamp(new Date().getTime());
+//		LoggingUtils.getLogger().info("Kafka message created", logMap);
+		LOGGER.info("Kafka message created");
+		return message;
+	}
+}

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendMessageFactory.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendMessageFactory.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.email;
 
-
 import java.util.Date;
 
 import org.springframework.stereotype.Service;
@@ -27,15 +26,16 @@ public class EmailSendMessageFactory {
 
 	/**
 	 * Creates an email-send avro message.
+	 * 
 	 * @param emailSend email-send object
 	 * @return email-send avro message
 	 * @throws SerializationException should there be a failure to serialize the EmailSend object
 	 */
-	public Message createMessage(final EmailSend emailSend, String orderReference) throws SerializationException {
+	public Message createMessage(final EmailSend emailSend, String penaltyReference) throws SerializationException {
         //Map<String, Object> logMap = LoggingUtils.createLogMapWithOrderReference(orderReference);
 //	    logMap.put(LoggingUtils.TOPIC, EMAIL_SEND_TOPIC);
 //		LoggingUtils.getLogger().info("Create kafka message", logMap);
-        LOGGER.info("Create kafka message");
+        LOGGER.info("Create kafka message for penalty reference: " + penaltyReference);
 		final AvroSerializer<EmailSend> serializer =
 				serializerFactory.getGenericRecordSerializer(EmailSend.class);
 		final Message message = new Message();

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendMessageProducer.java
@@ -1,21 +1,18 @@
 package uk.gov.companieshouse.email;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.stereotype.Service;
 
-import uk.gov.companieshouse.AppealApplication;
 import uk.gov.companieshouse.exception.ServiceException;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.message.Message;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.logging.LoggingUtils;
 
 @Service
 public class EmailSendMessageProducer {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
 
     private final EmailSendMessageFactory emailSendAvroSerializer;
     private final EmailSendKafkaProducer emailSendKafkaProducer;
@@ -34,33 +31,20 @@ public class EmailSendMessageProducer {
      * @throws InterruptedException should the execution thread be interrupted
      */
     public void sendMessage(final EmailSend email, String penaltyReference) {
-//        Map<String, Object> logMap = new HashMap<>();
-//        LoggingUtils.logWithOrderReference("Sending message to kafka producer", orderReference);
-    	LOGGER.info("Sending message to kafka producer: " + penaltyReference);
+        Map<String, Object> logMap = new HashMap<>();
+        LoggingUtils.logWithPenaltyReference("Sending message to kafka producer", penaltyReference);
     	try {
     		final Message message = emailSendAvroSerializer.createMessage(email, penaltyReference);
-//        LoggingUtils.logIfNotNull(logMap, LoggingUtils.TOPIC, message.getTopic());
+    		LoggingUtils.logIfNotNull(logMap, LoggingUtils.TOPIC, message.getTopic());
 			emailSendKafkaProducer.sendMessage(message, penaltyReference,
 			        recordMetadata ->
-			            logOffsetFollowingSendIngOfMessage(penaltyReference, recordMetadata));
+			            LoggingUtils.logOffsetFollowingSendIngOfMessage(penaltyReference, recordMetadata));
 		} catch (Exception e) {
             final String errorMessage
             	= String.format("Kafka 'email-send' message could not be sent for appeal with penalty reference - %s", penaltyReference);
-//		    logMap.put(LoggingUtils.EXCEPTION, e);
-//		    LOGGER.error(errorMessage, logMap);
+		    logMap.put(LoggingUtils.EXCEPTION, e);
+		    LoggingUtils.logException(errorMessage, logMap);
 		    throw new ServiceException(errorMessage, e);
 		}
-    }
-
-    /**
-     * Logs the order reference, topic, partition and offset for the item message produced to a Kafka topic.
-     * @param orderReference the order reference
-     * @param recordMetadata the metadata for a record that has been acknowledged by the server for the message produced
-     */
-    void logOffsetFollowingSendIngOfMessage(final String orderReference,
-                                            final RecordMetadata recordMetadata) {
-        //final Map<String, Object> logMapCallback =  createLogMapWithAcknowledgedKafkaMessage(recordMetadata);
-        //logIfNotNull(logMapCallback, ORDER_REFERENCE_NUMBER, orderReference);
-        //LOGGER.info("Message sent to Kafka topic", logMapCallback);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/email/EmailSendMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/email/EmailSendMessageProducer.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.email;
+
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class EmailSendMessageProducer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    private final EmailSendMessageFactory emailSendAvroSerializer;
+    private final EmailSendKafkaProducer emailSendKafkaProducer;
+
+    public EmailSendMessageProducer(final EmailSendMessageFactory avroSerializer,
+                                    final EmailSendKafkaProducer kafkaMessageProducer) {
+        this.emailSendAvroSerializer = avroSerializer;
+        this.emailSendKafkaProducer = kafkaMessageProducer;
+    }
+
+    /**
+     * Sends an email-send message to the Kafka producer.
+     * @param email EmailSend object encapsulating the message content
+     * @throws SerializationException should there be a failure to serialize the EmailSend object
+     * @throws ExecutionException should the production of the message to the topic error for some reason
+     * @throws InterruptedException should the execution thread be interrupted
+     */
+    public void sendMessage(final EmailSend email, String orderReference)
+            throws SerializationException, ExecutionException, InterruptedException {
+//        Map<String, Object> logMap =
+//      LoggingUtils.logWithOrderReference("Sending message to kafka producer", orderReference);
+    	LOGGER.info("Sending message to kafka producer: " + orderReference);
+        final Message message = emailSendAvroSerializer.createMessage(email, orderReference);
+//        LoggingUtils.logIfNotNull(logMap, LoggingUtils.TOPIC, message.getTopic());
+        emailSendKafkaProducer.sendMessage(message, orderReference,
+                recordMetadata ->
+                    logOffsetFollowingSendIngOfMessage(orderReference, recordMetadata));
+    }
+
+    /**
+     * Logs the order reference, topic, partition and offset for the item message produced to a Kafka topic.
+     * @param orderReference the order reference
+     * @param recordMetadata the metadata for a record that has been acknowledged by the server for the message produced
+     */
+    void logOffsetFollowingSendIngOfMessage(final String orderReference,
+                                            final RecordMetadata recordMetadata) {
+        //final Map<String, Object> logMapCallback =  createLogMapWithAcknowledgedKafkaMessage(recordMetadata);
+        //logIfNotNull(logMapCallback, ORDER_REFERENCE_NUMBER, orderReference);
+        //LOGGER.info("Message sent to Kafka topic", logMapCallback);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/email/KafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/email/KafkaProducer.java
@@ -1,0 +1,70 @@
+package uk.gov.companieshouse.email;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.kafka.exceptions.ProducerConfigException;
+import uk.gov.companieshouse.kafka.producer.Acks;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+public abstract class KafkaProducer implements InitializingBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    private CHKafkaProducer chKafkaProducer;
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String brokerAddresses;
+
+    @Override
+    public void afterPropertiesSet() {
+        LOGGER.trace("Configuring CH Kafka producer");
+        final ProducerConfig config = createProducerConfig();
+        config.setRoundRobinPartitioner(true);
+        config.setAcks(Acks.WAIT_FOR_ALL);
+        config.setRetries(10);
+        modifyProducerConfig(config);
+        chKafkaProducer = createChKafkaProducer(config);
+    }
+
+    /**
+     * Extending classes may implement this to provide any specific producer configuration modifications required.
+     * @param producerConfig the producer configuration to be modified
+     */
+    protected void modifyProducerConfig(final ProducerConfig producerConfig) {
+        // Does nothing here
+    }
+
+    protected CHKafkaProducer getChKafkaProducer() {
+        return chKafkaProducer;
+    }
+
+    /**
+     * Extending classes may implement this to facilitate testing for example.
+     * @return the {@link ProducerConfig} created
+     */
+    protected ProducerConfig createProducerConfig() {
+        final ProducerConfig config = new ProducerConfig();
+        if (brokerAddresses != null && !brokerAddresses.isEmpty()) {
+            config.setBrokerAddresses(brokerAddresses.split(","));
+        } else {
+            throw new ProducerConfigException("Broker addresses for kafka broker missing, check if environment variable KAFKA_BROKER_ADDR is configured. " +
+                    "[Hint: The property 'kafka.broker.addresses' uses the value of this environment variable in live environments " +
+                    "and that of 'spring.embedded.kafka.brokers' property in test.]");
+        }
+        return config;
+    }
+
+    /**
+     * Extending classes may implement this to facilitate testing for example.
+     * @param config the {@link ProducerConfig} used to configure the producer
+     * @return the {@link CHKafkaProducer} created
+     */
+    protected CHKafkaProducer createChKafkaProducer(final ProducerConfig config) {
+        return new CHKafkaProducer(config);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/exception/ServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/exception/ServiceException.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.exception;
+
+/**
+ * The class {@code ServiceException} is a form of {@code Exception}
+ * that should be used at the service layer to abstract lower level
+ * exceptions from being propagated up the call stack.
+ */
+public class ServiceException extends RuntimeException {
+
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 8335305656549044901L;
+
+	/**
+     * Constructs a new {@code ServiceException} with a custom message and the specified
+     * cause.
+     *
+     * @param message a custom message
+     * @param cause the cause
+     */
+    public ServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/logging/LoggingUtils.java
@@ -1,0 +1,122 @@
+package uk.gov.companieshouse.logging;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.kafka.message.Message;
+
+public class LoggingUtils {
+
+    private LoggingUtils() {
+        throw new IllegalStateException("A utility class is not to be instantiated");
+    }
+
+    public static final String TOPIC = "topic";
+    public static final String OFFSET = "offset";
+    public static final String KEY = "key";
+    public static final String PARTITION = "partition";
+    public static final String RETRY_ATTEMPT = "retry_attempt";
+    public static final String MESSAGE = "message";
+    public static final String CURRENT_TOPIC = "current_topic";
+    public static final String NEXT_TOPIC = "next_topic";
+    public static final String ORDER_RECEIVED_GROUP_ERROR = "order_received_error";
+    public static final String PENALTY_REFERENCE = "penalty_reference_number";
+    public static final String ORDER_URI = "order_uri";
+    public static final String DESCRIPTION_LOG_KEY = "description_key";
+    public static final String ITEM_ID = "item_id";
+    public static final String EXCEPTION = "exception";
+    public static final String PAYMENT_REFERENCE = "payment_reference";
+    public static final String COMPANY_NUMBER = "company_number";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    public static Map<String, Object> createLogMap() {
+        return new HashMap<>();
+    }
+
+    public static Map<String, Object> createLogMapWithKafkaMessage(Message message) {
+        Map<String, Object> logMap = createLogMap();
+        logIfNotNull(logMap, TOPIC, message.getTopic());
+        logIfNotNull(logMap, PARTITION, message.getPartition());
+        logIfNotNull(logMap, OFFSET, message.getOffset());
+        return logMap;
+    }
+
+    /**
+     * Creates a log map containing the required details to track the production of a message to a Kafka topic.
+     * @param acknowledgedMessage the {@link RecordMetadata} the metadata for a record that has been acknowledged by
+     *                            the server when a message has been produced to a Kafka topic.
+     * @return the log map populated with Kafka message production details
+     */
+	public static Map<String, Object> createLogMapWithAcknowledgedKafkaMessage(
+			final RecordMetadata acknowledgedMessage) {
+		final Map<String, Object> logMap = createLogMap();
+		logIfNotNull(logMap, TOPIC, acknowledgedMessage.topic());
+		logIfNotNull(logMap, PARTITION, acknowledgedMessage.partition());
+		logIfNotNull(logMap, OFFSET, acknowledgedMessage.offset());
+		return logMap;
+	}
+
+    public static Map<String, Object> createLogMapWithPenaltyReference(String penaltyReference) {
+        Map<String, Object> logMap = createLogMap();
+        logIfNotNull(logMap, PENALTY_REFERENCE, penaltyReference);
+        return logMap;
+    }
+
+    public static void logIfNotNull(Map<String, Object> logMap, String key, Object loggingObject) {
+        if (loggingObject != null) {
+            logMap.put(key, loggingObject);
+        }
+    }
+
+    public static Map<String, Object> logWithPenaltyReference(String logMessage,
+            String penaltyReference) {
+        Map<String, Object> logMap = createLogMapWithPenaltyReference(penaltyReference);
+        LOGGER.info(logMessage, logMap);
+        return logMap;
+    }
+
+    public static Map<String, Object> logMessageWithOrderReference(Message message,
+            String logMessage, String orderReference) {
+        Map<String, Object> logMap = createLogMapWithKafkaMessage(message);
+        logIfNotNull(logMap, PENALTY_REFERENCE, orderReference);
+        LOGGER.info(logMessage, logMap);
+        return logMap;
+    }
+    
+    public static void logException(String errorMessage, Map<String, Object> logMap) {
+	    LOGGER.error(errorMessage, logMap);
+    }
+
+    /**
+     * Logs the penalty reference, topic, partition and offset for the item message produced to a Kafka topic.
+     * @param penaltyReference the penalty reference
+     * @param recordMetadata the metadata for a record that has been acknowledged by the server for the message produced
+     */
+    public static void logOffsetFollowingSendIngOfMessage(final String penaltyReference,
+                                            final RecordMetadata recordMetadata) {
+        final Map<String, Object> logMapCallback =  LoggingUtils.createLogMapWithAcknowledgedKafkaMessage(recordMetadata);
+        logIfNotNull(logMapCallback, PENALTY_REFERENCE, penaltyReference);
+        LOGGER.info("Message sent to Kafka topic", logMapCallback);
+    }
+
+    public static Logger getLogger() {
+        return LOGGER;
+    }
+
+//    public static Map<String, Object> getMessageHeadersAsMap(
+//            org.springframework.messaging.Message<OrderReceived> message) {
+//        Map<String, Object> logMap = LoggingUtils.createLogMap();
+//        MessageHeaders messageHeaders = message.getHeaders();
+//
+//        logIfNotNull(logMap, KEY, messageHeaders.get(KafkaHeaders.RECEIVED_MESSAGE_KEY));
+//        logIfNotNull(logMap, TOPIC, messageHeaders.get(KafkaHeaders.RECEIVED_TOPIC));
+//        logIfNotNull(logMap, OFFSET, messageHeaders.get(KafkaHeaders.OFFSET));
+//        logIfNotNull(logMap, PARTITION, messageHeaders.get(KafkaHeaders.RECEIVED_PARTITION_ID));
+//
+//        return logMap;
+//    }
+}

--- a/src/main/java/uk/gov/companieshouse/model/Region.java
+++ b/src/main/java/uk/gov/companieshouse/model/Region.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.service;
+package uk.gov.companieshouse.model;
 
 public enum Region {
 	SC,

--- a/src/main/java/uk/gov/companieshouse/model/validator/EndDateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/model/validator/EndDateValidator.java
@@ -3,12 +3,21 @@ package uk.gov.companieshouse.model.validator;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+
 import org.springframework.stereotype.Component;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.model.Appeal;
 
 @Component
 public class EndDateValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
 
     static final String EMPTY_END_DATE = "Unable to validate. End date is empty";
     static final String END_DATE_CONTINUED_TRUE =
@@ -22,13 +31,20 @@ public class EndDateValidator {
     public String validateEndDate(Appeal appeal) {
         String rawStartDate = appeal.getReason().getIllness().getIllnessStart();
         String rawEndDate = appeal.getReason().getIllness().getIllnessEnd();
-        boolean continued = appeal.getReason().getIllness().getContinuedIllness();
+        Boolean continued = appeal.getReason().getIllness().getContinuedIllness();
 
-        if ((rawEndDate == null || rawEndDate.isEmpty()) && !continued) {
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put("rawStartDate", rawEndDate);
+        logMap.put("rawEndDate", rawEndDate);
+        logMap.put("continuedIllness", continued.toString());
+
+        LOGGER.debugContext(appeal.getPenaltyIdentifier().getPenaltyReference(), "Determine if illness end date is valid", logMap);
+        
+        if ((rawEndDate == null || rawEndDate.isEmpty()) && !continued.booleanValue()) {
             return EMPTY_END_DATE;
         }
 
-        if (rawEndDate != null && !rawEndDate.isEmpty() && continued) {
+        if (rawEndDate != null && !rawEndDate.isEmpty() && continued.booleanValue()) {
             return END_DATE_CONTINUED_TRUE;
         }
 

--- a/src/main/java/uk/gov/companieshouse/sdk/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/sdk/ApiClientService.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.sdk;
+
+import org.springframework.stereotype.Component;
+
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@Component
+public class ApiClientService {
+
+    public InternalApiClient getInternalApiClient() {
+        return ApiSdkManager.getPrivateSDK();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/service/AppealService.java
+++ b/src/main/java/uk/gov/companieshouse/service/AppealService.java
@@ -5,14 +5,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import uk.gov.companieshouse.AppealApplication;
 import uk.gov.companieshouse.client.ChipsRestClient;
 import uk.gov.companieshouse.config.ChipsConfiguration;
 import uk.gov.companieshouse.database.entity.AppealEntity;
 import uk.gov.companieshouse.exception.ChipsServiceException;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.mapper.AppealMapper;
@@ -40,6 +45,8 @@ public class AppealService {
     private ChipsConfiguration chipsConfiguration;
     @Autowired
     private ChipsContactDescriptionFormatter chipsContactDescriptionFormatter;
+    @Autowired
+    private EmailService emailService;
 
     public String saveAppeal(Appeal appeal, String userId) {
         appeal.setCreatedAt(LocalDateTime.now());
@@ -54,6 +61,13 @@ public class AppealService {
             LOGGER.debug("CHIPS feature is disabled");
         }
 
+        try {
+			emailService.sendAppealEmails(appeal);
+		} catch (JsonProcessingException | InterruptedException | ExecutionException | SerializationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        
         return appealId;
     }
 

--- a/src/main/java/uk/gov/companieshouse/service/AppealService.java
+++ b/src/main/java/uk/gov/companieshouse/service/AppealService.java
@@ -5,19 +5,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import uk.gov.companieshouse.AppealApplication;
 import uk.gov.companieshouse.client.ChipsRestClient;
 import uk.gov.companieshouse.config.ChipsConfiguration;
 import uk.gov.companieshouse.database.entity.AppealEntity;
 import uk.gov.companieshouse.exception.ChipsServiceException;
-import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.mapper.AppealMapper;
@@ -61,13 +58,8 @@ public class AppealService {
             LOGGER.debug("CHIPS feature is disabled");
         }
 
-        try {
-			emailService.sendAppealEmails(appeal);
-		} catch (JsonProcessingException | InterruptedException | ExecutionException | SerializationException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-        
+		emailService.sendAppealEmails(appeal);
+		
         return appealId;
     }
 

--- a/src/main/java/uk/gov/companieshouse/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/service/CompanyProfileService.java
@@ -37,10 +37,8 @@ public class CompanyProfileService {
         try {
             companyProfileApi = apiClient.company().get(uri).execute().getData();
         } catch (ApiErrorResponseException e) {
-
             throw new ServiceException("Error retrieving company profile", e);
         } catch (URIValidationException e) {
-
             throw new ServiceException("Invalid URI for company resource", e);
         }
 

--- a/src/main/java/uk/gov/companieshouse/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/service/CompanyProfileService.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.exception.ServiceException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.sdk.ApiClientService;
+
+@Service
+public class CompanyProfileService {
+	
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);	
+
+    private static final UriTemplate GET_COMPANY_URI = new UriTemplate("/company/{companyNumber}");
+
+    @Autowired
+    private ApiClientService apiClientService;
+
+    public CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException {
+
+    	LOGGER.debug("Get company profile for " + companyNumber);
+    	
+        ApiClient apiClient = apiClientService.getInternalApiClient();
+
+        CompanyProfileApi companyProfileApi;
+
+        String uri = GET_COMPANY_URI.expand(companyNumber).toString();
+
+        try {
+            companyProfileApi = apiClient.company().get(uri).execute().getData();
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Error retrieving company profile", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for company resource", e);
+        }
+
+        return companyProfileApi;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutionException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,6 +16,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.companieshouse.AppealApplication;
 import uk.gov.companieshouse.email.EmailSend;
 import uk.gov.companieshouse.email.EmailSendMessageProducer;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -32,29 +35,34 @@ public class EmailService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
 
-    private static final String LFP_APPEALS_API_APP_ID =
-    		"lfp-appeals-api";
+    private static final String LFP_APPEALS_API_APP_ID = "lfp-appeals-api";
     private static final String LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE =
             "lfp-appeal-submission-internal";
     private static final String LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE =
             "lfp-appeal-submission-confirmation";
+    private static final String LFP_APPEAL_INTERNAL_EMAIL_SUBJECT = "Appeal submitted - ";
+    private static final String LFP_APPEAL_CONFIRMATION_EMAIL_SUBJECT = "Confirmation of your appeal - ";
+    private static final String TEAM_EMAIL_SUFFIX = "_TEAM_EMAIL";
 
-    /**
-     * This email address is supplied only to satisfy Avro contract.
-     */
+    // This email address is supplied only to satisfy Avro contract.
     private static final String TOKEN_EMAIL_ADDRESS = "lfp-appeals@ch.gov.uk";
 
-     private final EmailSendMessageProducer producer;
-
+    private final EmailSendMessageProducer producer;
 
     public EmailService(EmailSendMessageProducer producer) {
         this.producer = producer;
     }
+    
+    @Bean
+    public static EnvironmentReader getEnvironmentReader() {
+        return new EnvironmentReaderImpl();
+    }
 
     /**
-     * Sends out a certificate or certified copy order confirmation email.
+     * Sends out LFP Appeal confirmation and internal emails.
      *
-     * @param appeal the order information used to compose the order confirmation email.
+     * @param appeal The appeal information used to compose the internal/confirmation emails.
+     * 
      * @throws JsonProcessingException
      * @throws InterruptedException
      * @throws ExecutionException
@@ -64,25 +72,22 @@ public class EmailService {
             throws JsonProcessingException, InterruptedException, ExecutionException, SerializationException {
 
     	sendInternalConfirmationEmail(appeal);
-    	//sendExternalConfirmationEmail(appeal);
+    	sendExternalConfirmationEmail(appeal);
     }
 
     /**
-     * Sends out a certificate or certified copy order confirmation email.
-     * @param messageType 
-     *
-     * @param appeal the order information used to compose the order confirmation email.
-     * @throws JsonProcessingException
-     * @throws InterruptedException
-     * @throws ExecutionException
-     * @throws SerializationException
+     * Build email header data.
+     * 
+     * @param emailType Type of email being sent.
+     * 
+     * @return email header with data
      */
-    private EmailSend getEmailHeader(String messageType) {
+    private EmailSend getEmailHeader(String emailType) {
 
         EmailSend email = new EmailSend();
 
         email.setAppId(LFP_APPEALS_API_APP_ID);
-        email.setMessageType(messageType);
+        email.setMessageType(emailType);
         email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
         email.setMessageId(UUID.randomUUID().toString());
         email.setCreatedAt(LocalDateTime.now().toString());
@@ -90,30 +95,53 @@ public class EmailService {
         return email;
     }
 
+    /**
+     * Send an internal lfp appeal email to kafka.
+     * 
+     * @param appeal The appeal information used to compose the internal/confirmation emails.
+     * 
+     * @throws SerializationException
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
     public void sendInternalConfirmationEmail(final Appeal appeal)
     		throws SerializationException, ExecutionException, InterruptedException {
 
         final EmailSend email = getEmailHeader(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
 
-        email.setData(buildEmailContent(appeal));
+        email.setData(buildEmailContent(appeal, LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE));
 
         producer.sendMessage(email, appeal.getPenaltyIdentifier().getPenaltyReference());
     }
 
+
+    /**
+     * Send an external lfp appeal email to kafka.
+     * 
+     * @param appeal The appeal information used to compose the internal/confirmation emails.
+     * 
+     * @throws SerializationException
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
     public void sendExternalConfirmationEmail(final Appeal appeal)
     		throws SerializationException, ExecutionException, InterruptedException {
 
         final EmailSend email = getEmailHeader(LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE);
 
-        email.setData(buildEmailContent(appeal));
+        email.setData(buildEmailContent(appeal, LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE));
 
         producer.sendMessage(email, appeal.getPenaltyIdentifier().getPenaltyReference());
     }
 
     /**
-     * Sends out a certificate or certified copy order confirmation email.
+     * Build the email content from the appeal information.
      *
-     * @param appeal the order information used to compose the order confirmation email.
+     * @param appeal The appeal information used to compose the internal/confirmation emails.
+     * @param emailType Type of email to build
+     * 
+     * @return Email content in JSON converted to String format
+     * 
      * @throws ServiceException 
      * @throws JSONException 
      * @throws JsonProcessingException
@@ -121,65 +149,103 @@ public class EmailService {
      * @throws ExecutionException
      * @throws SerializationException
      */    
-	private String buildEmailContent(Appeal appeal) {
+	private String buildEmailContent(Appeal appeal, String emailType) {
 
-		String email = appeal.getCreatedBy().getEmailAddress();
 		PenaltyIdentifier penaltyIdentifier = appeal.getPenaltyIdentifier();
 		String companyNumber = penaltyIdentifier.getCompanyNumber();
+		String usersEmail = appeal.getCreatedBy().getEmailAddress();
+
+		String emailTo;
+		String emailSubject;
+		if( emailType.equals(LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE)) {
+			emailTo = usersEmail;
+			emailSubject = LFP_APPEAL_CONFIRMATION_EMAIL_SUBJECT;
+		} else {
+			emailTo = determineInternalEmailAddressToSendTo(companyNumber);
+			emailSubject = LFP_APPEAL_INTERNAL_EMAIL_SUBJECT;			
+		}
 
 		JSONObject jsonEmailContent = new JSONObject();
-		jsonEmailContent.put("to", email);
-		jsonEmailContent.put("subject", "Appeal submitted - " + companyNumber);
-		
-		JSONObject jsonBody = new JSONObject();
-    	jsonBody.put("templateName", LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
-
-        JSONObject jsonTemplateData = new JSONObject();
-        jsonTemplateData.put("companyName", "company name");//getCompanyName(companyNumber));
-        jsonTemplateData.put("companyNumber", companyNumber);
-        jsonTemplateData.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
+		jsonEmailContent.put("to", emailTo);
+		jsonEmailContent.put("subject", emailSubject + companyNumber);
+		jsonEmailContent.put("companyName", "company name");//getCompanyName(companyNumber));
+		jsonEmailContent.put("companyNumber", companyNumber);
+		jsonEmailContent.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
 
         JSONObject jsonUserProfile = new JSONObject();
-        jsonUserProfile.put("email", email);
-        jsonTemplateData.put("userProfile", jsonUserProfile);
-        jsonTemplateData.put("reasons", addReasonsData(appeal));
-
-        jsonBody.put("templateData", jsonTemplateData);
-        jsonEmailContent.put("body", jsonBody);
+        jsonUserProfile.put("email", usersEmail);
+        jsonEmailContent.put("userProfile", jsonUserProfile);
+        
+        if( emailType.equals(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE)) {
+        	jsonEmailContent.put("reasons", addReasonsData(appeal));
+        }
         
         LOGGER.info("JSON Array: " + jsonEmailContent.toString());
         
         return jsonEmailContent.toString();
 	}
 	
+	/**
+	 * Works out the region email address to send the internal email to. Based on the if the company
+	 * starts with the allowed region prefixes of NI or SC, reads the appropriate environment variable.
+	 * If it doesn't start with either NI or SC then the default email address environment variable is used.
+	 * 
+	 * @param companyNumber Company number to check
+	 * 
+	 * @return Appropriate email address based on region 
+	 */
+	private String determineInternalEmailAddressToSendTo(String companyNumber) {
+		EnvironmentReader environmentReader = getEnvironmentReader();
+		for( Region reg : Region.values()) {
+			if(companyNumber.startsWith(reg.name())) {
+				return environmentReader.getMandatoryString(reg.name() + TEAM_EMAIL_SUFFIX);
+			}
+		}
+		return environmentReader.getMandatoryString(Region.DEFAULT + TEAM_EMAIL_SUFFIX);
+	}
+	
+	/**
+	 * Add reason information to be added to the email.
+	 *  
+	 * @param appeal The appeal information used to compose the internal/confirmation emails.
+	 * 
+	 * @return JSON of reason information
+	 */
 	private JSONObject addReasonsData(Appeal appeal) {
 
 		Reason appealReason = appeal.getReason();
 		
-		JSONObject jsonReason = new JSONObject();
-		jsonReason.put("name", appeal.getCreatedBy().getName());
+		JSONObject reasonData = new JSONObject();
+		reasonData.put("name", appeal.getCreatedBy().getName());
 		if( appealReason.getOther() != null ) {
-			jsonReason.put("relationshipToCompany", appeal.getCreatedBy().getRelationshipToCompany());
-			jsonReason.put("title", appeal.getReason().getOther().getTitle());
-			jsonReason.put("description", appeal.getReason().getOther().getDescription());
+			reasonData.put("relationshipToCompany", appeal.getCreatedBy().getRelationshipToCompany());
+			reasonData.put("title", appeal.getReason().getOther().getTitle());
+			reasonData.put("description", appeal.getReason().getOther().getDescription());
 		} else {
-			jsonReason.put("illPerson", appeal.getReason().getIllness().getIllPerson());
-			jsonReason.put("illnessStart", appeal.getReason().getIllness().getIllnessStart());
-			jsonReason.put("illnessEnd", appeal.getReason().getIllness().getIllnessEnd());		
+			reasonData.put("illPerson", appeal.getReason().getIllness().getIllPerson());
+			reasonData.put("illnessStart", appeal.getReason().getIllness().getIllnessStart());
+			reasonData.put("illnessEnd", appeal.getReason().getIllness().getIllnessEnd());		
+			reasonData.put("description", appeal.getReason().getIllness().getIllnessImpactFurtherInformation());
 		}
-		jsonReason.put("description", appeal.getReason().getOther().getDescription());
-		jsonReason.put("attachments", addAttachments(appeal));
+		reasonData.put("attachments", addAttachments(appeal));
         
-		JSONObject fullReason = new JSONObject();
+		JSONObject reason = new JSONObject();
 		if( appealReason.getOther() != null ) {
-			fullReason.put("other", jsonReason);
+			reason.put("other", reasonData);
 		} else {
-			fullReason.put("illness", jsonReason);
+			reason.put("illness", reasonData);
 		}
-        return fullReason;
+        return reason;
 		
 	}
     
+	/**
+	 * Add any attachment links to be added to the email.
+	 * 
+	 * @param appeal The appeal information used to compose the internal/confirmation emails.
+	 * 
+	 * @return JSON array containing any links to attachments.
+	 */
 	private JSONArray addAttachments(Appeal appeal) {
 
 		Reason reason = appeal.getReason();

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.service;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -14,8 +13,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import uk.gov.companieshouse.AppealApplication;
-import uk.gov.companieshouse.api.ApiClient;
-import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.email.EmailSend;
 import uk.gov.companieshouse.email.EmailSendMessageProducer;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
@@ -23,7 +20,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.model.Appeal;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 /**
  * Communicates with <code>chs-email-sender</code> via the <code>send-email</code> Kafka topic to
@@ -158,7 +154,7 @@ public class EmailService {
 //        data.put("attachments_download_url_prefix", emailAttachmentDownloadUrlPrefix);
 //    }
     
-	private void buildJson(Appeal appeal) throws JSONException, ServiceException {
+	private void buildJson(Appeal appeal) throws JSONException {
 
 		PenaltyIdentifier penaltyIdentifier = appeal.getPenaltyIdentifier();
 		String companyNumber = penaltyIdentifier.getCompanyNumber();
@@ -176,7 +172,7 @@ public class EmailService {
     	jsonBody.put("templateName", "lfp-appeal-submission-internal");
         //data.put("templateData", );
         JSONObject companyDetails = new JSONObject();
-        companyDetails.put("companyName", getCompanyName(companyNumber));
+        //companyDetails.put("companyName", getCompanyName(companyNumber));
         companyDetails.put("companyNumber", companyNumber);
         companyDetails.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
         jsonArray.put(companyDetails);
@@ -194,34 +190,34 @@ public class EmailService {
 		
 	}
     
-	private String getCompanyName(String companyNumber)
-		throws ServiceException {
-        try {
-//            Map<String, Object> logMap = new HashMap<>();
-//            logMap.put(LOG_COMPANY_NUMBER_KEY, companyNumber);
-
-            ApiClient apiClient = ApiSdkManager.getSDK();
-
-            String companyProfileUrl = String.format("/company/%s", companyNumber);
-
-//            apiLogger.infoContext(
-//                    requestId,
-//                    "Retrieving company details from the SDK",
-//                    logMap
-//            );
-
-            return apiClient.company().get(companyProfileUrl).execute().getData().getCompanyName();
-        } catch (IOException | URIValidationException e) {
-//            apiLogger.errorContext(
-//                    requestId,
+//	private String getCompanyName(String companyNumber)
+//		throws ServiceException {
+//        try {
+////            Map<String, Object> logMap = new HashMap<>();
+////            logMap.put(LOG_COMPANY_NUMBER_KEY, companyNumber);
+//
+//            ApiClient apiClient = ApiSdkManager.getSDK();
+//
+//            String companyProfileUrl = String.format("/company/%s", companyNumber);
+//
+////            apiLogger.infoContext(
+////                    requestId,
+////                    "Retrieving company details from the SDK",
+////                    logMap
+////            );
+//
+//            return apiClient.company().get(companyProfileUrl).execute().getData().getCompanyName();
+//        } catch (IOException | URIValidationException e) {
+////            apiLogger.errorContext(
+////                    requestId,
+////                    e);
+//
+//            throw new ServiceException(
+//                    String.format("Problem retrieving company details from the SDK for %s %s",
+//                            "company-number", companyNumber),
 //                    e);
-
-            throw new ServiceException(
-                    String.format("Problem retrieving company details from the SDK for %s %s",
-                            "company-number", companyNumber),
-                    e);
-        }
-    }
+//        }
+//    }
 
     /**
      * Builds the order confirmation and email based on the order provided.

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
@@ -10,7 +11,6 @@ import org.json.JSONObject;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import uk.gov.companieshouse.AppealApplication;
 import uk.gov.companieshouse.email.EmailSend;
@@ -19,7 +19,9 @@ import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.model.Appeal;
+import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
+import uk.gov.companieshouse.model.Reason;
 
 /**
  * Communicates with <code>chs-email-sender</code> via the <code>send-email</code> Kafka topic to
@@ -31,38 +33,21 @@ public class EmailService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
 
     private static final String LFP_APPEALS_API_APP_ID =
-    		AppealApplication.APP_NAMESPACE;
+    		"lfp-appeals-api";
     private static final String LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE =
             "lfp-appeal-submission-internal";
     private static final String LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE =
             "lfp-appeal-submission-confirmation";
-    private static final String ITEM_TYPE_CERTIFICATE = "certificate";
-    private static final String ITEM_TYPE_CERTIFIED_COPY = "certified-copy";
-    private static final String ITEM_TYPE_MISSING_IMAGE_DELIVERY = "missing-image-delivery";
 
     /**
      * This email address is supplied only to satisfy Avro contract.
      */
-    private static final String TOKEN_EMAIL_ADDRESS = "chs-orders@ch.gov.uk";
+    private static final String TOKEN_EMAIL_ADDRESS = "lfp-appeals@ch.gov.uk";
 
-//    private final OrderDataToCertificateOrderConfirmationMapper orderToCertificateOrderConfirmationMapper;
-//    private final OrderDataToItemOrderConfirmationMapper orderToItemOrderConfirmationMapper;
-    private final ObjectMapper objectMapper;
-    private final EmailSendMessageProducer producer;
+     private final EmailSendMessageProducer producer;
 
-//    @Value("${certificate.order.confirmation.recipient}")
-//    private String certificateOrderRecipient;
-//    @Value("${certified-copy.order.confirmation.recipient}")
-//    private String certifiedCopyOrderRecipient;
 
-    public EmailService(
-//            final OrderDataToCertificateOrderConfirmationMapper orderToConfirmationMapper,
-//            final OrderDataToItemOrderConfirmationMapper orderToItemOrderConfirmationMapper,
-            final ObjectMapper objectMapper,
-            final EmailSendMessageProducer producer) {
-//        this.orderToCertificateOrderConfirmationMapper = orderToConfirmationMapper;
-//        this.orderToItemOrderConfirmationMapper = orderToItemOrderConfirmationMapper;
-        this.objectMapper = objectMapper;
+    public EmailService(EmailSendMessageProducer producer) {
         this.producer = producer;
     }
 
@@ -84,6 +69,7 @@ public class EmailService {
 
     /**
      * Sends out a certificate or certified copy order confirmation email.
+     * @param messageType 
      *
      * @param appeal the order information used to compose the order confirmation email.
      * @throws JsonProcessingException
@@ -91,22 +77,37 @@ public class EmailService {
      * @throws ExecutionException
      * @throws SerializationException
      */
+    private EmailSend getEmailHeader(String messageType) {
+
+        EmailSend email = new EmailSend();
+
+        email.setAppId(LFP_APPEALS_API_APP_ID);
+        email.setMessageType(messageType);
+        email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
+        email.setMessageId(UUID.randomUUID().toString());
+        email.setCreatedAt(LocalDateTime.now().toString());
+        
+        return email;
+    }
+
     public void sendInternalConfirmationEmail(final Appeal appeal)
     		throws SerializationException, ExecutionException, InterruptedException {
 
-        final EmailSend email = new EmailSend();
+        final EmailSend email = getEmailHeader(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
 
-        email.setAppId(LFP_APPEALS_API_APP_ID);
-        email.setMessageType(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
-        email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
-        email.setMessageId(UUID.randomUUID().toString());
-        
-        //email.setData(objectMapper.writeValueAsString(confirmation));
-        email.setCreatedAt(LocalDateTime.now().toString());
+        email.setData(buildEmailContent(appeal));
 
-        String orderReference = appeal.getPenaltyIdentifier().getPenaltyReference();
-        //LoggingUtils.logWithOrderReference("Sending confirmation email for order", orderReference);
-        producer.sendMessage(email, orderReference);
+        producer.sendMessage(email, appeal.getPenaltyIdentifier().getPenaltyReference());
+    }
+
+    public void sendExternalConfirmationEmail(final Appeal appeal)
+    		throws SerializationException, ExecutionException, InterruptedException {
+
+        final EmailSend email = getEmailHeader(LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE);
+
+        email.setData(buildEmailContent(appeal));
+
+        producer.sendMessage(email, appeal.getPenaltyIdentifier().getPenaltyReference());
     }
 
     /**
@@ -119,77 +120,87 @@ public class EmailService {
      * @throws InterruptedException
      * @throws ExecutionException
      * @throws SerializationException
-     */
-//    public void sendExternalConfirmationEmail(final Appeal appeal) {
-//
-//        final EmailSend email = new EmailSend();
-//
-//        email.setAppId(LFP_APPEALS_API_APP_ID);
-//        email.setMessageType(LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE);
-//        email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
-//        email.setMessageId(UUID.randomUUID().toString());
-//        
-//        email.setData(objectMapper.writeValueAsString(confirmation));
-//        email.setCreatedAt(LocalDateTime.now().toString());
-//
-//        String orderReference = appeal.getPenaltyIdentifier().getPenaltyReference();
-//        //LoggingUtils.logWithOrderReference("Sending confirmation email for order", orderReference);
-//        producer.sendMessage(email, orderReference);
-//    }
+     */    
+	private String buildEmailContent(Appeal appeal) {
 
-//    private void buildData(Appeal appeal) {
-//        Map<String, Object> data = new HashMap<>();
-//
-//        LocalDateTime submittedOn = appeal.getCreatedAt();
-//
-//        data.put("subject", "Appeal submitted - " + appeal.getPenaltyIdentifier().getCompanyNumber());
-//        data.put("objection_id", objection.getId());
-//        data.put("to", TOKEN_EMAIL_ADDRESS);
-//        data.put("full_name", objection.getCreatedBy().getFullName());
-//        data.put("share_identity", objection.getCreatedBy().isShareIdentity());
-//        data.put("company_name", companyName);
-//        data.put("company_number", objection.getCompanyNumber());
-//        data.put("reason", objection.getReason());
-//        data.put("attachments", objection.getAttachments());
-//        data.put("attachments_download_url_prefix", emailAttachmentDownloadUrlPrefix);
-//    }
-    
-	private void buildJson(Appeal appeal) throws JSONException {
-
+		String email = appeal.getCreatedBy().getEmailAddress();
 		PenaltyIdentifier penaltyIdentifier = appeal.getPenaltyIdentifier();
 		String companyNumber = penaltyIdentifier.getCompanyNumber();
 
-		JSONArray jsonArray = new JSONArray();
-		
-		JSONObject jsonHead = new JSONObject();
-
-		jsonHead.put("to", TOKEN_EMAIL_ADDRESS);
-		jsonHead.put("subject", "Appeal submitted - " + companyNumber);
-		jsonArray.put(jsonHead);
+		JSONObject jsonEmailContent = new JSONObject();
+		jsonEmailContent.put("to", email);
+		jsonEmailContent.put("subject", "Appeal submitted - " + companyNumber);
 		
 		JSONObject jsonBody = new JSONObject();
+    	jsonBody.put("templateName", LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
 
-    	jsonBody.put("templateName", "lfp-appeal-submission-internal");
-        //data.put("templateData", );
-        JSONObject companyDetails = new JSONObject();
-        //companyDetails.put("companyName", getCompanyName(companyNumber));
-        companyDetails.put("companyNumber", companyNumber);
-        companyDetails.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
-        jsonArray.put(companyDetails);
-        JSONObject userProfile = new JSONObject();
-        userProfile.put("email", appeal.getCreatedBy().getEmailAddress());
-        jsonArray.put(userProfile);
-//        data.put("userProfile: {
-//                email: userProfile.email
-//            },
-//            reasons: buildEmailReasonContent(appeal)
-//    	
-//		json.t
+        JSONObject jsonTemplateData = new JSONObject();
+        jsonTemplateData.put("companyName", "company name");//getCompanyName(companyNumber));
+        jsonTemplateData.put("companyNumber", companyNumber);
+        jsonTemplateData.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
+
+        JSONObject jsonUserProfile = new JSONObject();
+        jsonUserProfile.put("email", email);
+        jsonTemplateData.put("userProfile", jsonUserProfile);
+        jsonTemplateData.put("reasons", addReasonsData(appeal));
+
+        jsonBody.put("templateData", jsonTemplateData);
+        jsonEmailContent.put("body", jsonBody);
         
-        LOGGER.info("JSON Array: " + jsonArray.toString());
+        LOGGER.info("JSON Array: " + jsonEmailContent.toString());
+        
+        return jsonEmailContent.toString();
+	}
+	
+	private JSONObject addReasonsData(Appeal appeal) {
+
+		Reason appealReason = appeal.getReason();
+		
+		JSONObject jsonReason = new JSONObject();
+		jsonReason.put("name", appeal.getCreatedBy().getName());
+		if( appealReason.getOther() != null ) {
+			jsonReason.put("relationshipToCompany", appeal.getCreatedBy().getRelationshipToCompany());
+			jsonReason.put("title", appeal.getReason().getOther().getTitle());
+			jsonReason.put("description", appeal.getReason().getOther().getDescription());
+		} else {
+			jsonReason.put("illPerson", appeal.getReason().getIllness().getIllPerson());
+			jsonReason.put("illnessStart", appeal.getReason().getIllness().getIllnessStart());
+			jsonReason.put("illnessEnd", appeal.getReason().getIllness().getIllnessEnd());		
+		}
+		jsonReason.put("description", appeal.getReason().getOther().getDescription());
+		jsonReason.put("attachments", addAttachments(appeal));
+        
+		JSONObject fullReason = new JSONObject();
+		if( appealReason.getOther() != null ) {
+			fullReason.put("other", jsonReason);
+		} else {
+			fullReason.put("illness", jsonReason);
+		}
+        return fullReason;
 		
 	}
     
+	private JSONArray addAttachments(Appeal appeal) {
+
+		Reason reason = appeal.getReason();
+
+		JSONArray attachmentArray = new JSONArray();
+
+		List<Attachment> attachments;
+		if( reason.getOther() != null ) {
+			attachments = reason.getOther().getAttachments();
+		} else {
+			attachments = reason.getIllness().getAttachments();
+		}
+		attachments.stream().forEach(a -> {
+			JSONObject jsonAttachments = new JSONObject();
+			jsonAttachments.put("name", a.getName());
+			jsonAttachments.put("url", a.getUrl() + "&a=" + appeal.getId());
+			attachmentArray.put(jsonAttachments);
+		});
+		
+		return attachmentArray;
+	}
 //	private String getCompanyName(String companyNumber)
 //		throws ServiceException {
 //        try {
@@ -218,42 +229,4 @@ public class EmailService {
 //                    e);
 //        }
 //    }
-
-    /**
-     * Builds the order confirmation and email based on the order provided.
-     * @param order the order for which an email confirmation is to be sent
-     * @return a {@link OrderConfirmationAndEmail} holding both the confirmation and its email envelope
-     */
-//    private OrderConfirmationAndEmail buildOrderConfirmationAndEmail(final OrderData order) {
-//        final String descriptionId = order.getItems().get(0).getDescriptionIdentifier();
-//        final EmailSend email = new EmailSend();
-//        final OrderConfirmation confirmation;
-//        switch (descriptionId) {
-//            case ITEM_TYPE_CERTIFICATE:
-//                confirmation = orderToCertificateOrderConfirmationMapper.orderToConfirmation(order);
-//                confirmation.setTo(certificateOrderRecipient);
-//                email.setAppId(LFP_APPEALS_API_APP_ID);
-//                email.setMessageType(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
-//                return new OrderConfirmationAndEmail(confirmation, email);
-//            case ITEM_TYPE_CERTIFIED_COPY:
-//                confirmation = orderToItemOrderConfirmationMapper.orderToConfirmation(order);
-//                confirmation.setTo(certifiedCopyOrderRecipient);
-//                email.setAppId(CERTIFIED_COPY_ORDER_NOTIFICATION_API_APP_ID);
-//                email.setMessageType(CERTIFIED_COPY_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
-//                return new OrderConfirmationAndEmail(confirmation, email);
-//            case ITEM_TYPE_MISSING_IMAGE_DELIVERY:
-//                confirmation = orderToItemOrderConfirmationMapper.orderToConfirmation(order);
-//                confirmation.setTo(missingImageDeliveryOrderRecipient);
-//                email.setAppId(MISSING_IMAGE_DELIVERY_ORDER_NOTIFICATION_API_APP_ID);
-//                email.setMessageType(MISSING_IMAGE_DELIVERY_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
-//                return new OrderConfirmationAndEmail(confirmation, email);
-//            default:
-//                final Map<String, Object> logMap = LoggingUtils.createLogMapWithOrderReference(order.getReference());
-//                final String error = "Unable to determine order confirmation type from description ID " +
-//                        descriptionId + "!";
-//                LOGGER.error(error, logMap);
-//                throw new ServiceException(error);
-//        }
-//    }
-
 }

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -1,0 +1,263 @@
+package uk.gov.companieshouse.service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.gov.companieshouse.AppealApplication;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.email.EmailSend;
+import uk.gov.companieshouse.email.EmailSendMessageProducer;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.model.Appeal;
+import uk.gov.companieshouse.model.PenaltyIdentifier;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+/**
+ * Communicates with <code>chs-email-sender</code> via the <code>send-email</code> Kafka topic to
+ * trigger the sending of emails.
+ */
+@Service
+public class EmailService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppealApplication.APP_NAMESPACE);
+
+    private static final String LFP_APPEALS_API_APP_ID =
+    		AppealApplication.APP_NAMESPACE;
+    private static final String LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE =
+            "lfp-appeal-submission-internal";
+    private static final String LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE =
+            "lfp-appeal-submission-confirmation";
+    private static final String ITEM_TYPE_CERTIFICATE = "certificate";
+    private static final String ITEM_TYPE_CERTIFIED_COPY = "certified-copy";
+    private static final String ITEM_TYPE_MISSING_IMAGE_DELIVERY = "missing-image-delivery";
+
+    /**
+     * This email address is supplied only to satisfy Avro contract.
+     */
+    private static final String TOKEN_EMAIL_ADDRESS = "chs-orders@ch.gov.uk";
+
+//    private final OrderDataToCertificateOrderConfirmationMapper orderToCertificateOrderConfirmationMapper;
+//    private final OrderDataToItemOrderConfirmationMapper orderToItemOrderConfirmationMapper;
+    private final ObjectMapper objectMapper;
+    private final EmailSendMessageProducer producer;
+
+//    @Value("${certificate.order.confirmation.recipient}")
+//    private String certificateOrderRecipient;
+//    @Value("${certified-copy.order.confirmation.recipient}")
+//    private String certifiedCopyOrderRecipient;
+
+    public EmailService(
+//            final OrderDataToCertificateOrderConfirmationMapper orderToConfirmationMapper,
+//            final OrderDataToItemOrderConfirmationMapper orderToItemOrderConfirmationMapper,
+            final ObjectMapper objectMapper,
+            final EmailSendMessageProducer producer) {
+//        this.orderToCertificateOrderConfirmationMapper = orderToConfirmationMapper;
+//        this.orderToItemOrderConfirmationMapper = orderToItemOrderConfirmationMapper;
+        this.objectMapper = objectMapper;
+        this.producer = producer;
+    }
+
+    /**
+     * Sends out a certificate or certified copy order confirmation email.
+     *
+     * @param appeal the order information used to compose the order confirmation email.
+     * @throws JsonProcessingException
+     * @throws InterruptedException
+     * @throws ExecutionException
+     * @throws SerializationException
+     */
+    public void sendAppealEmails(final Appeal appeal)
+            throws JsonProcessingException, InterruptedException, ExecutionException, SerializationException {
+
+    	sendInternalConfirmationEmail(appeal);
+    	//sendExternalConfirmationEmail(appeal);
+    }
+
+    /**
+     * Sends out a certificate or certified copy order confirmation email.
+     *
+     * @param appeal the order information used to compose the order confirmation email.
+     * @throws JsonProcessingException
+     * @throws InterruptedException
+     * @throws ExecutionException
+     * @throws SerializationException
+     */
+    public void sendInternalConfirmationEmail(final Appeal appeal)
+    		throws SerializationException, ExecutionException, InterruptedException {
+
+        final EmailSend email = new EmailSend();
+
+        email.setAppId(LFP_APPEALS_API_APP_ID);
+        email.setMessageType(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
+        email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
+        email.setMessageId(UUID.randomUUID().toString());
+        
+        //email.setData(objectMapper.writeValueAsString(confirmation));
+        email.setCreatedAt(LocalDateTime.now().toString());
+
+        String orderReference = appeal.getPenaltyIdentifier().getPenaltyReference();
+        //LoggingUtils.logWithOrderReference("Sending confirmation email for order", orderReference);
+        producer.sendMessage(email, orderReference);
+    }
+
+    /**
+     * Sends out a certificate or certified copy order confirmation email.
+     *
+     * @param appeal the order information used to compose the order confirmation email.
+     * @throws ServiceException 
+     * @throws JSONException 
+     * @throws JsonProcessingException
+     * @throws InterruptedException
+     * @throws ExecutionException
+     * @throws SerializationException
+     */
+//    public void sendExternalConfirmationEmail(final Appeal appeal) {
+//
+//        final EmailSend email = new EmailSend();
+//
+//        email.setAppId(LFP_APPEALS_API_APP_ID);
+//        email.setMessageType(LFP_APPEAL_SUBMISSION_CONFIRMATION_MESSAGE_TYPE);
+//        email.setEmailAddress(TOKEN_EMAIL_ADDRESS);
+//        email.setMessageId(UUID.randomUUID().toString());
+//        
+//        email.setData(objectMapper.writeValueAsString(confirmation));
+//        email.setCreatedAt(LocalDateTime.now().toString());
+//
+//        String orderReference = appeal.getPenaltyIdentifier().getPenaltyReference();
+//        //LoggingUtils.logWithOrderReference("Sending confirmation email for order", orderReference);
+//        producer.sendMessage(email, orderReference);
+//    }
+
+//    private void buildData(Appeal appeal) {
+//        Map<String, Object> data = new HashMap<>();
+//
+//        LocalDateTime submittedOn = appeal.getCreatedAt();
+//
+//        data.put("subject", "Appeal submitted - " + appeal.getPenaltyIdentifier().getCompanyNumber());
+//        data.put("objection_id", objection.getId());
+//        data.put("to", TOKEN_EMAIL_ADDRESS);
+//        data.put("full_name", objection.getCreatedBy().getFullName());
+//        data.put("share_identity", objection.getCreatedBy().isShareIdentity());
+//        data.put("company_name", companyName);
+//        data.put("company_number", objection.getCompanyNumber());
+//        data.put("reason", objection.getReason());
+//        data.put("attachments", objection.getAttachments());
+//        data.put("attachments_download_url_prefix", emailAttachmentDownloadUrlPrefix);
+//    }
+    
+	private void buildJson(Appeal appeal) throws JSONException, ServiceException {
+
+		PenaltyIdentifier penaltyIdentifier = appeal.getPenaltyIdentifier();
+		String companyNumber = penaltyIdentifier.getCompanyNumber();
+
+		JSONArray jsonArray = new JSONArray();
+		
+		JSONObject jsonHead = new JSONObject();
+
+		jsonHead.put("to", TOKEN_EMAIL_ADDRESS);
+		jsonHead.put("subject", "Appeal submitted - " + companyNumber);
+		jsonArray.put(jsonHead);
+		
+		JSONObject jsonBody = new JSONObject();
+
+    	jsonBody.put("templateName", "lfp-appeal-submission-internal");
+        //data.put("templateData", );
+        JSONObject companyDetails = new JSONObject();
+        companyDetails.put("companyName", getCompanyName(companyNumber));
+        companyDetails.put("companyNumber", companyNumber);
+        companyDetails.put("penaltyReference", penaltyIdentifier.getPenaltyReference());
+        jsonArray.put(companyDetails);
+        JSONObject userProfile = new JSONObject();
+        userProfile.put("email", appeal.getCreatedBy().getEmailAddress());
+        jsonArray.put(userProfile);
+//        data.put("userProfile: {
+//                email: userProfile.email
+//            },
+//            reasons: buildEmailReasonContent(appeal)
+//    	
+//		json.t
+        
+        LOGGER.info("JSON Array: " + jsonArray.toString());
+		
+	}
+    
+	private String getCompanyName(String companyNumber)
+		throws ServiceException {
+        try {
+//            Map<String, Object> logMap = new HashMap<>();
+//            logMap.put(LOG_COMPANY_NUMBER_KEY, companyNumber);
+
+            ApiClient apiClient = ApiSdkManager.getSDK();
+
+            String companyProfileUrl = String.format("/company/%s", companyNumber);
+
+//            apiLogger.infoContext(
+//                    requestId,
+//                    "Retrieving company details from the SDK",
+//                    logMap
+//            );
+
+            return apiClient.company().get(companyProfileUrl).execute().getData().getCompanyName();
+        } catch (IOException | URIValidationException e) {
+//            apiLogger.errorContext(
+//                    requestId,
+//                    e);
+
+            throw new ServiceException(
+                    String.format("Problem retrieving company details from the SDK for %s %s",
+                            "company-number", companyNumber),
+                    e);
+        }
+    }
+
+    /**
+     * Builds the order confirmation and email based on the order provided.
+     * @param order the order for which an email confirmation is to be sent
+     * @return a {@link OrderConfirmationAndEmail} holding both the confirmation and its email envelope
+     */
+//    private OrderConfirmationAndEmail buildOrderConfirmationAndEmail(final OrderData order) {
+//        final String descriptionId = order.getItems().get(0).getDescriptionIdentifier();
+//        final EmailSend email = new EmailSend();
+//        final OrderConfirmation confirmation;
+//        switch (descriptionId) {
+//            case ITEM_TYPE_CERTIFICATE:
+//                confirmation = orderToCertificateOrderConfirmationMapper.orderToConfirmation(order);
+//                confirmation.setTo(certificateOrderRecipient);
+//                email.setAppId(LFP_APPEALS_API_APP_ID);
+//                email.setMessageType(LFP_APPEAL_SUBMISSION_INTERNAL_MESSAGE_TYPE);
+//                return new OrderConfirmationAndEmail(confirmation, email);
+//            case ITEM_TYPE_CERTIFIED_COPY:
+//                confirmation = orderToItemOrderConfirmationMapper.orderToConfirmation(order);
+//                confirmation.setTo(certifiedCopyOrderRecipient);
+//                email.setAppId(CERTIFIED_COPY_ORDER_NOTIFICATION_API_APP_ID);
+//                email.setMessageType(CERTIFIED_COPY_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
+//                return new OrderConfirmationAndEmail(confirmation, email);
+//            case ITEM_TYPE_MISSING_IMAGE_DELIVERY:
+//                confirmation = orderToItemOrderConfirmationMapper.orderToConfirmation(order);
+//                confirmation.setTo(missingImageDeliveryOrderRecipient);
+//                email.setAppId(MISSING_IMAGE_DELIVERY_ORDER_NOTIFICATION_API_APP_ID);
+//                email.setMessageType(MISSING_IMAGE_DELIVERY_ORDER_NOTIFICATION_API_MESSAGE_TYPE);
+//                return new OrderConfirmationAndEmail(confirmation, email);
+//            default:
+//                final Map<String, Object> logMap = LoggingUtils.createLogMapWithOrderReference(order.getReference());
+//                final String error = "Unable to determine order confirmation type from description ID " +
+//                        descriptionId + "!";
+//                LOGGER.error(error, logMap);
+//                throw new ServiceException(error);
+//        }
+//    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/service/Region.java
+++ b/src/main/java/uk/gov/companieshouse/service/Region.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.service;
+
+public enum Region {
+	SC,
+	NI,
+	DEFAULT;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
   data:
     mongodb:
       uri: ${APPEALS_API_MONGODB_URL}
+  kafka:
+    bootstrap-servers: ${KAFKA_BROKER_ADDR} 
 
 chips:
   enabled: ${CHIPS_FEATURE_ENABLED}
@@ -13,3 +15,4 @@ chips:
 
 companyNumber:
   prefixes: ${ALLOWED_COMPANY_PREFIXES}
+

--- a/src/test/java/uk/gov/companieshouse/TestData.java
+++ b/src/test/java/uk/gov/companieshouse/TestData.java
@@ -11,6 +11,7 @@ public class TestData {
     public static final String RELATIONSHIP = "relationship";
     public static final String EMAIL = "user@example.com";
     public static final String COMPANY_NUMBER = "12345678";
+    public static final String COMPANY_NAME = "Test company";
     public static final String PENALTY_REFERENCE = "A12345678";
     public static final String TITLE = "Some title";
     public static final String DESCRIPTION = "Some description";
@@ -26,5 +27,5 @@ public class TestData {
     public static final int ATTACHMENT_SIZE = 100;
     public static final String ATTACHMENT_URL = "http://localhost/appeal-a-penalty/download/prompt/1?c=00345567";
     public static final String RELATIONSHIP_ERROR_MESSAGE = "Createdby.RelationshipToCompany must not be null when supplying Other Reason";
-
+    public static final String EXCEPTION_MESSAGE = "BAD THINGS";
 }

--- a/src/test/java/uk/gov/companieshouse/TestUtil.java
+++ b/src/test/java/uk/gov/companieshouse/TestUtil.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.database.entity.IllnessReasonEntity;
 import uk.gov.companieshouse.database.entity.OtherReasonEntity;
 import uk.gov.companieshouse.database.entity.PenaltyIdentifierEntity;
 import uk.gov.companieshouse.database.entity.ReasonEntity;
+import uk.gov.companieshouse.email.EmailSend;
 import uk.gov.companieshouse.model.Appeal;
 import uk.gov.companieshouse.model.Attachment;
 import uk.gov.companieshouse.model.CreatedBy;
@@ -15,6 +16,7 @@ import uk.gov.companieshouse.model.IllnessReason;
 import uk.gov.companieshouse.model.OtherReason;
 import uk.gov.companieshouse.model.PenaltyIdentifier;
 import uk.gov.companieshouse.model.Reason;
+import uk.gov.companieshouse.service.EmailService;
 
 public class TestUtil {
     public static IllnessReason createIllnessReason() {
@@ -140,4 +142,15 @@ public class TestUtil {
         return createdByEntity;
     }
 
+//    public static EmailSend createEmailSend() {
+//        EmailSend emailSend = new EmailSend();
+//        emailSend.setAppId(EmailService.LFP_APPEALS_API_APP_ID);
+//        emailSend.setData(EMAIL_DATA);
+//        emailSend.setEmailAddress(TestData.EMAIL);
+//        emailSend.setMessageId(MSG_ID);
+//        emailSend.setMessageType(MSG_TYPE);
+//        emailSend.setCreatedAt(TestData.CREATED_AT);
+//
+//        return emailSend;
+//    }
 }

--- a/src/test/java/uk/gov/companieshouse/controller/AppealControllerGetTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/AppealControllerGetTest.java
@@ -7,17 +7,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import uk.gov.companieshouse.model.Appeal;
 import uk.gov.companieshouse.model.CreatedBy;
 import uk.gov.companieshouse.model.OtherReason;
@@ -26,8 +30,9 @@ import uk.gov.companieshouse.model.Reason;
 import uk.gov.companieshouse.service.AppealService;
 
 @SpringBootTest
+@EmbeddedKafka
 @AutoConfigureMockMvc
-public class AppealControllerTest_GET {
+class AppealControllerGetTest {
 
     private final String APPEALS_URI = "/companies/{company-id}/appeals";
     private final String TEST_RESOURCE_ID = "1";
@@ -43,7 +48,7 @@ public class AppealControllerTest_GET {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void whenAppealExistsById_return200() throws Exception {
+    void whenAppealExistsById_return200() throws Exception {
 
         when(appealService.getAppeal(any(String.class))).thenReturn(Optional.of(getValidOtherAppeal()));
 
@@ -56,7 +61,7 @@ public class AppealControllerTest_GET {
     }
 
     @Test
-    public void whenAppealDoesNotExistById_return404() throws Exception {
+    void whenAppealDoesNotExistById_return404() throws Exception {
 
         when(appealService.getAppeal(any(String.class))).thenReturn(Optional.empty());
 
@@ -67,7 +72,7 @@ public class AppealControllerTest_GET {
     }
 
     @Test
-    public void whenAppealExistsByPenalty_return200() throws Exception {
+    void whenAppealExistsByPenalty_return200() throws Exception {
 
         when(appealService.getAppealsByPenaltyReference(any(String.class))).thenReturn(List.of(getValidOtherAppeal()));
 
@@ -81,7 +86,7 @@ public class AppealControllerTest_GET {
     }
 
     @Test
-    public void whenAppealDoesNotExistByPenalty_return404() throws Exception {
+    void whenAppealDoesNotExistByPenalty_return404() throws Exception {
 
         when(appealService.getAppealsByPenaltyReference(any(String.class))).thenReturn(List.of());
 

--- a/src/test/java/uk/gov/companieshouse/email/EmailSendMessageFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/email/EmailSendMessageFactoryTest.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.email;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka
+class EmailSendMessageFactoryTest {
+    @Autowired
+    private SerializerFactory serializerFactory;
+
+    private static final String APP_ID = "App Id";
+    private static final String EMAIL_DATA = "Message content";
+    private static final String EMAIL_ADDR = "someone@example.com";
+    private static final String MSG_ID = "Message Id";
+    private static final String MSG_TYPE = "Message type";
+    private static final String PENALTY_REF = "A12345678";
+    private static final String CREATED_AT = "2020-08-25T09:27:09.519+01:00";
+
+    private static final String TOPIC = "email-send";
+
+    @Test
+    void createMessageSuccessfullyCreatesMessage() throws Exception {
+        // Given
+        EmailSendMessageFactory messageFactory = new EmailSendMessageFactory(serializerFactory);
+
+        // When
+        Message message = messageFactory.createMessage(createEmailSend(), PENALTY_REF);
+        String actualContent = new String(message.getValue());
+
+        // Then
+        AvroSerializer<EmailSend> serializer = serializerFactory.getGenericRecordSerializer(EmailSend.class);
+        String expectedContent = new String(serializer.toBinary(createEmailSend()));
+        Assertions.assertEquals(expectedContent, actualContent);
+        Assertions.assertEquals(TOPIC, message.getTopic());
+    }
+
+    private EmailSend createEmailSend() {
+        EmailSend emailSend = new EmailSend();
+        emailSend.setAppId(APP_ID);
+        emailSend.setData(EMAIL_DATA);
+        emailSend.setEmailAddress(EMAIL_ADDR);
+        emailSend.setMessageId(MSG_ID);
+        emailSend.setMessageType(MSG_TYPE);
+        emailSend.setCreatedAt(CREATED_AT);
+
+        return emailSend;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/email/EmailSendMessageProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/email/EmailSendMessageProducerIntegrationTest.java
@@ -1,0 +1,167 @@
+package uk.gov.companieshouse.email;
+
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka
+class EmailSendMessageProducerIntegrationTest {
+
+    private static final String ORDER_REFERENCE = "ORD-432118-793830";
+
+    private static final DateTimeFormatter TIME_OF_PAYMENT_FORMATTER =
+            DateTimeFormatter.ofPattern("dd MMMM yyyy 'at' hh:mm");
+
+//    @Autowired
+//    EmailSendMessageProducer emailSendMessageProducerUnderTest;
+
+//    @Autowired
+//    TestEmailSendMessageConsumer testEmailSendMessageConsumer;
+
+    @Autowired
+    SerializerFactory serializerFactory;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+//    @Test
+//    @DisplayName("Can send certificate order confirmation to email-send")
+//    void testSendCertificateOrderConfirmationMessageToKafkaTopic() throws Exception {
+//
+//        // Given an EmailSend object is created
+//        final CertificateOrderConfirmation confirmation = new CertificateOrderConfirmation();
+//        confirmation.setTo("nobody@nowhere.com");
+//
+//        confirmation.setForename("Jenny");
+//        confirmation.setSurname("Wilson");
+//
+//        confirmation.setAddressLine1("Kemp House Capital Office");
+//        confirmation.setAddressLine2("LTD");
+//        confirmation.setHouseName("Kemp House");
+//        confirmation.setHouseNumberStreetName("152-160 City Road");
+//        confirmation.setCity("London");
+//        confirmation.setPostCode("EC1V 2NX");
+//        confirmation.setOrderReferenceNumber(ORDER_REFERENCE);
+//        confirmation.setEmailAddress("mail@globaloffshore.com");
+//        confirmation.setDeliveryMethod("Standard delivery");
+//        confirmation.setFeeAmount("15");
+//        confirmation.setTimeOfPayment(TIME_OF_PAYMENT_FORMATTER.format(LocalDateTime.now()));
+//        confirmation.setPaymentReference("RS5VSNDRE");
+//        confirmation.setCompanyName("GLOBAL OFFSHORE HOST LIMITED");
+//        confirmation.setCompanyNumber("11260147");
+//        confirmation.setCertificateType("Incorporation with all company name changes");
+//        confirmation.setCertificateIncludes(new String[]{
+//                "Statement of good standing",
+//                "Registered office address",
+//                "Directors",
+//                "Secretaries",
+//                "Company objects"
+//        });
+//
+//        final EmailSend email = new EmailSend();
+//        email.setAppId("item-handler.certificate-order-confirmation");
+//        email.setEmailAddress("test@test.com");
+//        email.setMessageId(UUID.randomUUID().toString());
+//        email.setMessageType("certificate_order_confirmation_email");
+//        email.setData(objectMapper.writeValueAsString(confirmation));
+//        email.setCreatedAt(LocalDateTime.now().toString());
+//
+//        // When email-send message is sent to kafka topic
+//        final List<Message> messages = sendAndConsumeMessage(email);
+//
+//        // Then we can successfully consume the message.
+//        assertThat(messages.isEmpty(), is(false));
+//        byte[] consumedMessageSerialized = messages.get(0).getValue();
+//        final String deserializedConsumedMessage = new String(consumedMessageSerialized);
+//
+//        // and it matches the serialized email-send object sent
+//        final AvroSerializer<EmailSend> serializer = serializerFactory.getGenericRecordSerializer(EmailSend.class);
+//        final byte[] serializedEmail = serializer.toBinary(email);
+//        final String deserializedEmail = new String(serializedEmail);
+//
+//        assertEquals(deserializedConsumedMessage, deserializedEmail);
+//    }
+//
+//    @Test
+//    @DisplayName("Can send missing image delivery order confirmation to email-send")
+//    void testSendMissingImageDeliveryOrderConfirmationMessageToKafkaTopic() throws Exception {
+//
+//        // Given an EmailSend object is created
+//        final ItemOrderConfirmation confirmation = new ItemOrderConfirmation();
+//        confirmation.setTo("nobody@nowhere.com");
+//
+//        confirmation.setForename("Jenny");
+//        confirmation.setSurname("Wilson");
+//
+//        confirmation.setAddressLine1("Kemp House Capital Office");
+//        confirmation.setAddressLine2("LTD");
+//        confirmation.setHouseName("Kemp House");
+//        confirmation.setHouseNumberStreetName("152-160 City Road");
+//        confirmation.setCity("London");
+//        confirmation.setPostCode("EC1V 2NX");
+//        confirmation.setOrderReferenceNumber(ORDER_REFERENCE);
+//        confirmation.setEmailAddress("mail@globaloffshore.com");
+//        confirmation.setTimeOfPayment(TIME_OF_PAYMENT_FORMATTER.format(LocalDateTime.now()));
+//        confirmation.setPaymentReference("RS5VSNDRE");
+//        confirmation.setCompanyName("GLOBAL OFFSHORE HOST LIMITED");
+//        confirmation.setCompanyNumber("11260147");
+//        final ItemDetails missingImage = new ItemDetails();
+//        missingImage.setDateFiled("15 Feb 2018");
+//        missingImage.setDescription("Appointment of Ms Sharon Michelle White as a director on 4 February 2020");
+//        missingImage.setFee("3");
+//        missingImage.setType("AP01");
+//        confirmation.setItemDetails(singletonList(missingImage));
+//
+//        final EmailSend email = new EmailSend();
+//        email.setAppId("item-handler.missing-image-delivery-order-confirmation");
+//        email.setEmailAddress("test@test.com");
+//        email.setMessageId(UUID.randomUUID().toString());
+//        email.setMessageType("missing_image_delivery_order_confirmation_email");
+//        email.setData(objectMapper.writeValueAsString(confirmation));
+//        email.setCreatedAt(LocalDateTime.now().toString());
+//
+//        // When email-send message is sent to kafka topic
+//        final List<Message> messages = sendAndConsumeMessage(email);
+//
+//        // Then we can successfully consume the message.
+//        assertThat(messages.isEmpty(), is(false));
+//        byte[] consumedMessageSerialized = messages.get(0).getValue();
+//        final String deserializedConsumedMessage = new String(consumedMessageSerialized);
+//
+//        // and it matches the serialized email-send object sent
+//        final AvroSerializer<EmailSend> serializer = serializerFactory.getGenericRecordSerializer(EmailSend.class);
+//        final byte[] serializedEmail = serializer.toBinary(email);
+//        final String deserializedEmail = new String(serializedEmail);
+//
+//        assertEquals(deserializedConsumedMessage, deserializedEmail);
+//    }
+//
+//    private List<Message> sendAndConsumeMessage(final EmailSend email) throws Exception {
+//        List<Message> messages;
+//        testEmailSendMessageConsumer.connect();
+//        int count = 0;
+//        do {
+//            messages = testEmailSendMessageConsumer.pollConsumerGroup();
+//            sendMessageOnce(email, count);
+//            count++;
+//        } while (messages.isEmpty() && count < 15);
+//
+//        return messages;
+//    }
+
+//    private void sendMessageOnce(final EmailSend email, final int count) throws Exception {
+//        if (count == 0) {
+//            emailSendMessageProducerUnderTest.sendMessage(email, ORDER_REFERENCE);
+//        }
+//    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/email/EmailSendMessageProducerTest.java
+++ b/src/test/java/uk/gov/companieshouse/email/EmailSendMessageProducerTest.java
@@ -1,0 +1,75 @@
+package uk.gov.companieshouse.email;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.logging.LoggingUtils.PENALTY_REFERENCE;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.logging.Logger;
+
+/**
+ * Unit tests the {@link EmailSendMessageProducer} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailSendMessageProducerTest {
+
+    @InjectMocks
+    private EmailSendMessageProducer messageProducerUnderTest;
+
+    @Mock
+    private EmailSendMessageFactory emailSendMessageFactory;
+
+    @Mock
+    private EmailSendKafkaProducer emailSendKafkaProducer;
+
+    @Mock
+    private Message message;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private EmailSend emailSend;
+
+    @Test
+    @DisplayName("sendMessage delegates message creation to EmailSendMessageFactory")
+    void sendMessageDelegatesMessageCreation() throws Exception {
+
+        // Given
+        when(emailSendMessageFactory.createMessage(emailSend, PENALTY_REFERENCE)).thenReturn(message);
+
+        // When
+        messageProducerUnderTest.sendMessage(emailSend, PENALTY_REFERENCE);
+
+        // Then
+        verify(emailSendMessageFactory).createMessage(emailSend, PENALTY_REFERENCE);
+
+    }
+
+    @SuppressWarnings("unchecked")
+	@Test
+    @DisplayName("sendMessage delegates message sending to EmailSendKafkaProducer")
+    void sendMessageDelegatesMessageSending() throws Exception {
+
+        // Given
+        when(emailSendMessageFactory.createMessage(emailSend, PENALTY_REFERENCE)).thenReturn(message);
+
+        // When
+        messageProducerUnderTest.sendMessage(emailSend, PENALTY_REFERENCE);
+
+        // Then
+        verify(emailSendKafkaProducer).sendMessage(eq(message), eq(PENALTY_REFERENCE), any(Consumer.class));
+
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/email/KafkaProducerTest.java
+++ b/src/test/java/uk/gov/companieshouse/email/KafkaProducerTest.java
@@ -1,0 +1,146 @@
+package uk.gov.companieshouse.email;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.kafka.exceptions.ProducerConfigException;
+import uk.gov.companieshouse.kafka.producer.Acks;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests the {@link KafkaProducer} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class KafkaProducerTest {
+
+    private static final String EXPECTED_CONFIG_ERROR_MESSAGE =
+        "Broker addresses for kafka broker missing, check if environment variable KAFKA_BROKER_ADDR is configured. " +
+                "[Hint: The property 'kafka.broker.addresses' uses the value of this environment variable in live " +
+                "environments and that of 'spring.embedded.kafka.brokers' property in test.]";
+
+    @InjectMocks
+    private TestKafkaProducer kafkaProducerUnderTest;
+
+    @Mock
+    private CHKafkaProducer chKafkaProducer;
+
+    @Mock
+    private ProducerConfig producerConfig;
+
+    /**
+     * Extends {@link KafkaProducer} to provide a concrete implementation for testing.
+     */
+    private static class TestKafkaProducer extends KafkaProducer {}
+
+    /**
+     * Extends {@link KafkaProducer} to provide a concrete implementation for testing that allows us to stub out
+     * unwanted behaviour and verify the behaviour of interest.
+     */
+    private class TestKafkaProducer2 extends KafkaProducer {
+        private boolean modifyProducerConfigCalled;
+        private boolean createProducerConfigCalled;
+        private boolean createChKafkaProducerCalled;
+
+        public boolean isModifyProducerConfigCalled() {
+            return modifyProducerConfigCalled;
+        }
+
+        public boolean isCreateProducerConfigCalled() {
+            return createProducerConfigCalled;
+        }
+
+        public boolean isCreateChKafkaProducerCalled() {
+            return createChKafkaProducerCalled;
+        }
+
+        @Override
+        protected void modifyProducerConfig(ProducerConfig producerConfig) {
+            modifyProducerConfigCalled = true;
+        }
+
+        @Override
+        protected ProducerConfig createProducerConfig() {
+            createProducerConfigCalled = true;
+            return producerConfig;
+        }
+
+        @Override
+        protected CHKafkaProducer createChKafkaProducer(final ProducerConfig config) {
+            createChKafkaProducerCalled = true;
+            return chKafkaProducer;
+        }
+    }
+
+    @Test
+    @DisplayName("afterPropertiesSet() throws a ProducerConfigException if no spring.kafka.bootstrap-servers value configured")
+    void afterPropertiesSetThrowsExceptionIfNoBrokersConfigured() {
+
+        // When
+        ProducerConfigException exception = Assertions.assertThrows(ProducerConfigException.class, () ->
+                kafkaProducerUnderTest.afterPropertiesSet());
+        // Then
+        final String actualMessage = exception.getMessage();
+        assertThat(actualMessage, is(EXPECTED_CONFIG_ERROR_MESSAGE));
+
+    }
+
+    @Test
+    @DisplayName("afterPropertiesSet() calls template methods")
+    void afterPropertiesSetCallsTemplateMethods() {
+
+        // Given
+        final TestKafkaProducer2 kafkaProducerUnderTest = new TestKafkaProducer2();
+
+        // When
+        kafkaProducerUnderTest.afterPropertiesSet();
+
+        // Then
+        assertThat(kafkaProducerUnderTest.isModifyProducerConfigCalled(), is(true));
+        assertThat(kafkaProducerUnderTest.isCreateProducerConfigCalled(), is(true));
+        assertThat(kafkaProducerUnderTest.isCreateChKafkaProducerCalled(), is(true));
+
+    }
+
+    @Test
+    @DisplayName("afterPropertiesSet() sets the producer's kafka producer member")
+    void afterPropertiesSetSetsProducerMember() {
+
+        // Given
+        final TestKafkaProducer2 kafkaProducerUnderTest = new TestKafkaProducer2();
+
+        // When
+        kafkaProducerUnderTest.afterPropertiesSet();
+
+        // Then
+        assertThat(kafkaProducerUnderTest.getChKafkaProducer(), is(notNullValue()));
+
+    }
+
+    @Test
+    @DisplayName("afterPropertiesSet() sets producer config properties")
+    void afterPropertiesSetSetsProducerConfigProperties() {
+
+        // Given
+        final TestKafkaProducer2 kafkaProducerUnderTest = new TestKafkaProducer2();
+
+        // When
+        kafkaProducerUnderTest.afterPropertiesSet();
+
+        // Then
+        verify(producerConfig).setRoundRobinPartitioner(true);
+        verify(producerConfig).setAcks(Acks.WAIT_FOR_ALL);
+        verify(producerConfig).setRetries(10);
+
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/service/EmailServiceTests.java
+++ b/src/test/java/uk/gov/companieshouse/service/EmailServiceTests.java
@@ -1,0 +1,188 @@
+package uk.gov.companieshouse.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.TestData;
+import uk.gov.companieshouse.TestUtil;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.email.EmailSend;
+import uk.gov.companieshouse.email.EmailSendMessageProducer;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.exception.EnvironmentVariableException;
+import uk.gov.companieshouse.exception.ServiceException;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.model.Appeal;
+import uk.gov.companieshouse.model.CreatedBy;
+import uk.gov.companieshouse.model.Reason;
+import uk.gov.companieshouse.model.Region;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTests {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private EmailSendMessageProducer emailSendMessageProducer;
+
+    @Mock
+    private EnvironmentReader environmentReader;
+    
+    @Mock
+    private CompanyProfileService companyProfileService;
+    
+    @Mock
+    private CompanyProfileApi companyProfileApi;
+    
+    @Mock
+    private ApiErrorResponseException apiErrorResponseException;
+    
+    @Mock
+    private URIValidationException uriValidationException;
+    
+    @Mock
+    private SerializationException serializationException; 
+    @Mock
+    private ExecutionException executionException;
+    @Mock
+    private InterruptedException interruptedException;
+
+    private CreatedBy createdBy;
+    private Reason reason;
+    private Appeal appeal;
+    
+    @BeforeEach
+    private void setUp() {
+        createdBy = TestUtil.buildCreatedBy();
+        reason = TestUtil.createReasonWithOther();
+        appeal = TestUtil.createAppeal(createdBy, reason);
+    }
+    
+    @DisplayName("Succuessfully send an internal and external email")
+    @Test
+    void testSendInternalExternalEmailsSuccessfully() {
+        
+        doNothing().when(emailSendMessageProducer).sendMessage(ArgumentMatchers.any(EmailSend.class), ArgumentMatchers.anyString());
+
+        when(companyProfileService.getCompanyProfile(TestData.COMPANY_NUMBER)).thenReturn(companyProfileApi);
+        when(environmentReader.getMandatoryString(Region.DEFAULT + EmailService.TEAM_EMAIL_SUFFIX)).thenReturn(TestData.EMAIL);
+
+        emailService.sendAppealEmails(appeal);
+        
+        verify(emailSendMessageProducer, times(2)).sendMessage(ArgumentMatchers.any(EmailSend.class), ArgumentMatchers.anyString());
+    }
+
+    @DisplayName("Unsuccuessfully send emails due to EnvironmentVariableException thrown when determining region email address")
+    @Test
+    void testGetRegionEmailAddressThrowsEnvironmentVariableException() {
+        
+        final EnvironmentVariableException exception = new EnvironmentVariableException(TestData.EXCEPTION_MESSAGE);
+
+        when(environmentReader.getMandatoryString(Region.DEFAULT + EmailService.TEAM_EMAIL_SUFFIX)).thenThrow(exception);
+        
+        EnvironmentVariableException thrown = assertThrows(EnvironmentVariableException.class, () -> emailService.sendAppealEmails(appeal));
+
+        assertEquals(exception.getCause(), thrown.getCause());
+        assertEquals(exception.getMessage(), thrown.getMessage());
+    }
+
+    @DisplayName("Unsuccuessfully send emails due to ServiceException (ApiErrorResponseException) thrown when retrieving company name")
+    @Test
+    void testGetCompanyNameThrowsServiceExceptionOfTypeApiValidationException() {
+        
+    	final ServiceException exception = new ServiceException(TestData.EXCEPTION_MESSAGE, apiErrorResponseException);
+        
+        testExceptionHandingForGettingCompanyProfile(exception, apiErrorResponseException);
+    }
+
+    @DisplayName("Unsuccuessfully send emails due to ServiceException (URIValidationException) thrown when retrieving company name")
+    @Test
+    void testGetCompanyNameThrowsServiceExceptionOfTypeURIValidationException() {
+        
+        final ServiceException exception = new ServiceException(TestData.EXCEPTION_MESSAGE, uriValidationException);
+        
+        testExceptionHandingForGettingCompanyProfile(exception, uriValidationException);
+    }
+    
+    /**
+     * Common method for handling calling the kafka producer exception tests.
+     * 
+     * @param exceptionToThrow
+     * @param exceptionToCheck
+     */
+    private void testExceptionHandingForGettingCompanyProfile(Exception exceptionToThrow, Exception exceptionToCheck) {
+
+        when(companyProfileService.getCompanyProfile(TestData.COMPANY_NUMBER)).thenThrow(exceptionToThrow);
+        when(environmentReader.getMandatoryString(Region.DEFAULT + EmailService.TEAM_EMAIL_SUFFIX)).thenReturn(TestData.EMAIL);
+        
+        ServiceException thrown = assertThrows(ServiceException.class, () -> emailService.sendAppealEmails(appeal));
+
+        assertEquals(exceptionToCheck, thrown.getCause());
+        assertEquals(exceptionToThrow.getMessage(), thrown.getMessage());
+    }
+
+    @DisplayName("Call to kafka producer throws SerializationException")
+    @Test
+    void testThrowServiceExceptionOfTypeSerializationExceptionWhenCallingProducer() {
+        
+        final ServiceException exception = new ServiceException(TestData.EXCEPTION_MESSAGE, serializationException);
+        
+        testExceptionHandingForProducer(exception, serializationException);
+    }
+    
+    @DisplayName("Call to kafka producer throws ExecutionException")
+    @Test
+    void testThrowServiceExceptionOfTypeExecutionExceptionWhenCallingProducer() {
+        
+        final ServiceException exception = new ServiceException(TestData.EXCEPTION_MESSAGE, executionException);
+        
+        testExceptionHandingForProducer(exception, executionException);
+    }
+    
+    @DisplayName("Call to kafka producer throws InterruptedException")
+    @Test
+    void testThrowServiceExceptionOfTypeInterruptedExceptionWhenCallingProducer() {
+        
+        final ServiceException exception = new ServiceException(TestData.EXCEPTION_MESSAGE, interruptedException);
+        
+        testExceptionHandingForProducer(exception, interruptedException);
+    }
+    
+    /**
+     * Common method for handling calling the kafka producer exception tests.
+     * 
+     * @param exceptionToThrow
+     * @param exceptionToCheck
+     */
+    private void testExceptionHandingForProducer(Exception exceptionToThrow, Exception exceptionToCheck) {
+        
+        doThrow(exceptionToThrow).when(emailSendMessageProducer).sendMessage(ArgumentMatchers.any(EmailSend.class), ArgumentMatchers.anyString());
+
+        when(companyProfileService.getCompanyProfile(TestData.COMPANY_NUMBER)).thenReturn(companyProfileApi);
+        when(environmentReader.getMandatoryString(Region.DEFAULT + EmailService.TEAM_EMAIL_SUFFIX)).thenReturn(TestData.EMAIL);
+        
+        ServiceException thrown = assertThrows(ServiceException.class, () -> emailService.sendAppealEmails(appeal));
+
+        assertEquals(exceptionToCheck, thrown.getCause());
+        assertEquals(exceptionToThrow.getMessage(), thrown.getMessage());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,8 @@ spring:
   data:
     mongodb:
       uri: "mongodb://localhost/test"
+  kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers} 
 
 chips:
   enabled: true


### PR DESCRIPTION
### JIRA link
[BI-8916](https://companieshouse.atlassian.net/browse/BI-8916)


### Change description

Add EmailService to create the data for an email and send it to kafka. This is part of migrating of the use of kafka in lfp-appeals-frontend to lfp-appeals-api.

### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__