### PR TITLE
Update regex to allow alphanumerics of length between 8 & 14 chars

### DIFF
--- a/src/main/java/uk/gov/companieshouse/model/PenaltyIdentifier.java
+++ b/src/main/java/uk/gov/companieshouse/model/PenaltyIdentifier.java
@@ -13,7 +13,7 @@ public class PenaltyIdentifier {
     private String companyNumber;
 
     @NotBlank(message = "penaltyReference must not be blank")
-    @Pattern(regexp = "^[A-Z][0-9]{8}$|^PEN\\s?[1-2]A\\/[0-9]{8}$",
+    @Pattern(regexp = "[A-Z0-9/]{8,14}",
         message = "Unable to Validate. penaltyReference is invalid")
     private String penaltyReference;
 

--- a/src/test/java/uk/gov/companieshouse/TestData.java
+++ b/src/test/java/uk/gov/companieshouse/TestData.java
@@ -12,7 +12,7 @@ public class TestData {
     public static final String EMAIL = "user@example.com";
     public static final String COMPANY_NUMBER = "12345678";
     public static final String COMPANY_NAME = "Test company";
-    public static final String PENALTY_REFERENCE = "A12345678";
+    public static final String PENALTY_REFERENCE = "A1234567";
     public static final String TITLE = "Some title";
     public static final String DESCRIPTION = "Some description";
     public static final String ILL_PERSON = "someoneElse";

--- a/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/AppealServiceTest.java
@@ -46,6 +46,7 @@ class AppealServiceTest {
     private static final String APPEAL_ID = "appeal_id";
     private static final String PENALTY_REF = "penalty_reference";
     private static final String COMPANY_NUMBER = "company_number";
+	private static final String UNABLE_TO_SAVE_APPEAL_ERROR_MESSAGE = "Appeal not saved in database for companyNumber: 12345678, penaltyReference: A1234567 and userId: USER#1";
 
     @Mock
     private ChipsContactDescriptionFormatter chipsContactDescriptionFormatter;
@@ -108,7 +109,7 @@ class AppealServiceTest {
         when(appealRepository.insert(any(AppealEntity.class))).thenReturn(TestUtil.createAppealEntity(null, createdByEntity, reasonEntity));
 
         String message = assertThrows(Exception.class, () -> appealService.saveAppeal(TestUtil.createAppeal(createdBy, reason), TestData.USER_ID)).getMessage();
-        assertEquals("Appeal not saved in database for companyNumber: 12345678, penaltyReference: A12345678 and userId: USER#1", message);
+        assertEquals(UNABLE_TO_SAVE_APPEAL_ERROR_MESSAGE, message);
     }
 
     @Test
@@ -121,7 +122,7 @@ class AppealServiceTest {
         when(appealRepository.insert(any(AppealEntity.class))).thenReturn(null);
 
         String message = assertThrows(Exception.class, () -> appealService.saveAppeal(TestUtil.createAppeal(createdBy, reason), TestData.USER_ID)).getMessage();
-        assertEquals("Appeal not saved in database for companyNumber: 12345678, penaltyReference: A12345678 and userId: USER#1", message);
+        assertEquals(UNABLE_TO_SAVE_APPEAL_ERROR_MESSAGE, message);
     }
 
     @Test

--- a/src/test/resources/data/validOldPenaltyReferenceWhitespaceAppeal.json
+++ b/src/test/resources/data/validOldPenaltyReferenceWhitespaceAppeal.json
@@ -1,7 +1,7 @@
 {
   "penaltyIdentifier": {
     "companyNumber": "12345678",
-    "penaltyReference": "PEN 1A/09627488"
+    "penaltyReference": "PEN1A/09627488"
   },
   "reasons": {
     "other": {


### PR DESCRIPTION
### JIRA link

[BI-9419](https://companieshouse.atlassian.net/browse/BI-9419)

### Change description

Update regex in PenaltyIdentifier to be less restrictive and allow alphanumerics and a length of between 8 & 14 characters.
Update any affected tests. In AppealServiceTest created a constant for an error message that was used twice.

### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__