### PR TITLE
Update structured-logging to latest version 1.9.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <!-- Versions -->
         <version.spring.boot>2.4.3</version.spring.boot>
         <commons-lang3.version>3.10</commons-lang3.version>
-        <structured-logging.version>1.5.0-rc2</structured-logging.version>
+        <structured-logging.version>1.9.11</structured-logging.version>
         <kafka-models.version>1.0.17</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <avro.version>1.8.1</avro.version>
@@ -31,6 +31,7 @@
         <environment-reader-library.version>1.3.8</environment-reader-library.version>
         <httpclient.version>4.5.13</httpclient.version>
         <spring-kafka-test.version>2.7.7</spring-kafka-test.version>
+        <json.version>20211205</json.version>
     </properties>
 
     <repositories>
@@ -40,7 +41,7 @@
         </repository>
     </repositories>
 
-    <dependencies>
+	<dependencies>
         <!-- Spring/SpringBoot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -62,7 +63,6 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
             <version>${version.spring.boot}</version>
         </dependency>
-
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
@@ -130,6 +130,11 @@
 		    <version>4.0.0</version>
 		    <scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.version}</version>
+       	</dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Added dependency for org.json as updating the structured logging version caused issues when building service. This service did not include the log4j-core dependency.

[DEBT-1453](https://companieshouse.atlassian.net/browse/DEBT-1453)


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__