### PR TITLE
Prevent duplicate appeal records

### DIFF
--- a/src/main/java/uk/gov/companieshouse/repository/AppealRepository.java
+++ b/src/main/java/uk/gov/companieshouse/repository/AppealRepository.java
@@ -17,5 +17,8 @@ public interface AppealRepository extends MongoRepository<AppealEntity, String> 
     @Query("{ 'penaltyIdentifier.penaltyReference' : ?0 }")
     List<AppealEntity> findByPenaltyReference(String penaltyReference);
 
+    @Query("{ 'penaltyIdentifier.companyNumber' : ?0, 'penaltyIdentifier.penaltyReference' : ?1 }")
+    List<AppealEntity> findByCompanyNumberPenaltyReference(String companyNumber, String penaltyReference);
+
     void deleteById(String id);
 }

--- a/src/test/java/uk/gov/companieshouse/controller/AppealControllerGetTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/AppealControllerGetTest.java
@@ -77,7 +77,7 @@ class AppealControllerGetTest {
     @Test
     void whenAppealExistsByPenalty_return200() throws Exception {
 
-        when(appealService.getAppealsByPenaltyReference(any(String.class))).thenReturn(List.of(getValidOtherAppeal()));
+    	when(appealService.getAppealsByPenaltyReference(any(String.class), any(String.class))).thenReturn(List.of(getValidOtherAppeal()));
 
         final String validAppeal = asJsonArray();
 
@@ -91,7 +91,7 @@ class AppealControllerGetTest {
     @Test
     void whenAppealDoesNotExistByPenalty_return404() throws Exception {
 
-        when(appealService.getAppealsByPenaltyReference(any(String.class))).thenReturn(List.of());
+        when(appealService.getAppealsByPenaltyReference(any(String.class), any(String.class))).thenReturn(List.of());
 
         mockMvc.perform(get(APPEALS_URI, TEST_COMPANY_ID)
             .queryParam("penaltyReference", TEST_PENALTY_ID)


### PR DESCRIPTION
### JIRA link
[BI-11981](https://companieshouse.atlassian.net/browse/BI-11981)

### Change description
Before creating an appeal, added a check to see if an appeal for the company number/reference exists. If there are duplicates the first record is updated with the current date/time and the reason passed in updated. Add new test for updating an appeal
Updated some of the logging calls to use the penalty reference as the context.


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__