### PR TITLE
Bump spring boot version to 2.7.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions -->
-        <version.spring.boot>2.4.3</version.spring.boot>
+        <version.spring.boot>2.7.16</version.spring.boot>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <structured-logging.version>1.9.11</structured-logging.version>
         <kafka-models.version>1.0.17</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <avro.version>1.11.1</avro.version>
         <rest-service-common-library.version>0.0.5</rest-service-common-library.version>
-        <api-sdk-java.version>4.3.8</api-sdk-java.version>
+        <api-sdk-java.version>4.3.31</api-sdk-java.version>
         <private-api-sdk-java.version>2.0.94</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <environment-reader-library.version>1.3.8</environment-reader-library.version>

--- a/src/test/java/uk/gov/companieshouse/controller/AppealControllerPostTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/AppealControllerPostTest.java
@@ -98,7 +98,7 @@ class AppealControllerPostTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(validAppeal))
             .andExpect(status().isBadRequest())
-            .andExpect(status().reason("Missing request header 'ERIC-identity' for method parameter of type String"));
+            .andExpect(status().reason("Required request header 'ERIC-identity' for method parameter type String is not present"));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link
[DEPT-1979](https://companieshouse.atlassian.net/browse/DEBT-1979)


### Change description
There was an original dependabot PR, https://github.com/companieshouse/lfp-appeals-api/pull/168, would have bump spring-boot-starter-web from 2.4.3 to 2.5.12 for a critical vulnerability. This was superseded by a couple more dependabot PRs to go to version 3..0.0. Bumping to 3.0.0 caused build failures so for now I have bumped up to the last version 2 of spring boot, 2.7.16.
Bumped version of api-sdk-java as per Martin Westacott [message](https://companieshouse.slack.com/archives/C010DSNSMQT/p1700745012899859).
Updated expected message for one of the tests in AppealControllerPostTest as it was failing.


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__